### PR TITLE
Change test_entrypoint.gd to check for errors in GDScript

### DIFF
--- a/test/gdscript_tests/table_iterate.gd
+++ b/test/gdscript_tests/table_iterate.gd
@@ -2,11 +2,14 @@ extends RefCounted
 
 var lua_state = LuaState.new()
 
-func test():
+func test() -> bool:
+	var all_success = true
 	for i in range(0, 5):
-		test_n(i)
+		if not test_n(i):
+			all_success = false
+	return all_success
 
-func test_n(n: int):
+func test_n(n: int) -> bool:
 	var table = lua_state.create_table()
 	
 	for i in n:
@@ -16,3 +19,4 @@ func test_n(n: int):
 	for k in table:
 		iteration_count += 1
 	assert(iteration_count == n, "Iterated %d times over LuaTable with %d items" % [iteration_count, n])
+	return true

--- a/test/script_templates/RefCounted/test_script.gd
+++ b/test/script_templates/RefCounted/test_script.gd
@@ -1,0 +1,5 @@
+extends _BASE_
+
+
+func test() -> bool:
+	return true

--- a/test/test_entrypoint.gd
+++ b/test/test_entrypoint.gd
@@ -1,13 +1,16 @@
 extends SceneTree
 
+const LUA_TEST_DIR = "res://lua_tests"
+const GDSCRIPT_TEST_DIR = "res://gdscript_tests"
+
 func _initialize():
 	var all_success = true
 	
-	for lua_script in DirAccess.get_files_at("res://lua_tests"):
+	for lua_script in DirAccess.get_files_at(LUA_TEST_DIR):
 		var lua_state = LuaState.new()
 		lua_state.open_libraries()
 		
-		var file_name = "res://lua_tests/" + lua_script
+		var file_name = str(LUA_TEST_DIR, "/", lua_script)
 		var result = lua_state.do_file(file_name)
 		if result is LuaError:
 			all_success = false
@@ -15,9 +18,13 @@ func _initialize():
 		else:
 			print("✓ ", lua_script)
 
-	for gdscript in DirAccess.get_files_at("res://gdscript_tests"):
-		var file_name = "res://gdscript_tests/" + gdscript
+	for gdscript in DirAccess.get_files_at(GDSCRIPT_TEST_DIR):
+		var file_name = str(GDSCRIPT_TEST_DIR, "/", gdscript)
 		var obj = load(file_name).new()
-		obj.test()
+		if not obj.test():
+			all_success = false
+			printerr("🗴 ", gdscript)
+		else:
+			print("✓ ", gdscript)
 	
 	quit(0 if all_success else -1)


### PR DESCRIPTION
When GDScript functions error, the function simply returns `null`, so now we use `true` to mark tests as successful