### PR TITLE
Package Path project settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `LuaState.LoadMode` enum for specifying the Lua load mode: text, binary or any
 - `LuaState.do_buffer` and `LuaState.load_buffer` methods for loading Lua code from possibly binary chunks
 - `LuaState.package_path` and `LuaState.package_cpath` properties for accessing the value of Lua's [`package.path`](https://www.lua.org/manual/5.4/manual.html#pdf-package.path) and [`package.cpath`](https://www.lua.org/manual/5.4/manual.html#pdf-package.cpath)
+- Advanced project settings for setting the `LuaScriptLanguage` state's `package_path` and `package_cpath` properties
 
 ### Changed
 - The GDExtension is now marked as reloadable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - `LuaState.LoadMode` enum for specifying the Lua load mode: text, binary or any
 - `LuaState.do_buffer` and `LuaState.load_buffer` methods for loading Lua code from possibly binary chunks
 - `LuaState.package_path` and `LuaState.package_cpath` properties for accessing the value of Lua's [`package.path`](https://www.lua.org/manual/5.4/manual.html#pdf-package.path) and [`package.cpath`](https://www.lua.org/manual/5.4/manual.html#pdf-package.cpath)
+- `LuaState.get_lua_exec_dir` static method to get the executable directory used to replace "!" when setting `package_path` and `package_cpath` properties.
+  When running in the Godot editor, it returns the globalized version of `res://` path.
+  Otherwise, it returns the base directory of the executable.
 - Advanced project settings for setting the `LuaScriptLanguage` state's `package_path` and `package_cpath` properties
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Optional support for `res://` and `user://` relative paths in package searchers, `loadfile` and `dofile`.
   Open the `GODOT_LOCAL_PATHS` library to activate this behavior.
 - `LuaState.LoadMode` enum for specifying the Lua load mode: text, binary or any
-- `LuaState.do_buffer` and `LuaState.load_buffer` for loading Lua code from possibly binary chunks
+- `LuaState.do_buffer` and `LuaState.load_buffer` methods for loading Lua code from possibly binary chunks
+- `LuaState.package_path` and `LuaState.package_cpath` properties for accessing the value of Lua's [`package.path`](https://www.lua.org/manual/5.4/manual.html#pdf-package.path) and [`package.cpath`](https://www.lua.org/manual/5.4/manual.html#pdf-package.cpath)
 
 ### Changed
 - The GDExtension is now marked as reloadable

--- a/src/LuaState.cpp
+++ b/src/LuaState.cpp
@@ -28,7 +28,9 @@
 #include "utils/module_names.hpp"
 
 #include <godot_cpp/core/binder_common.hpp>
-#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
 #include <luaconf.h>
 
 namespace luagdextension {
@@ -191,6 +193,7 @@ void LuaState::set_package_path(const String& path) {
 			path.replace(";;", LUA_PATH_SEP LUA_PATH_DEFAULT LUA_PATH_SEP)
 				.rstrip(LUA_PATH_SEP)
 				.lstrip(LUA_PATH_SEP)
+				.replace(LUA_EXEC_DIR, get_lua_exec_dir())
 		);
 	}
 	else {
@@ -204,11 +207,18 @@ void LuaState::set_package_cpath(const String& cpath) {
 			cpath.replace(";;", LUA_PATH_SEP LUA_CPATH_DEFAULT LUA_PATH_SEP)
 				.rstrip(LUA_PATH_SEP)
 				.lstrip(LUA_PATH_SEP)
+				.replace(LUA_EXEC_DIR, get_lua_exec_dir())
 		);
 	}
 	else {
 		ERR_FAIL_MSG("LUA_PACKAGE library is not opened");
 	}
+}
+
+String LuaState::get_lua_exec_dir() {
+	return Engine::get_singleton()->is_editor_hint()
+		? ProjectSettings::get_singleton()->globalize_path("res://")
+		: OS::get_singleton()->get_executable_path().get_base_dir();
 }
 
 LuaState *LuaState::find_lua_state(lua_State *L) {
@@ -268,6 +278,7 @@ void LuaState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_package_cpath"), &LuaState::get_package_cpath);
 	ClassDB::bind_method(D_METHOD("set_package_path", "path"), &LuaState::set_package_path);
 	ClassDB::bind_method(D_METHOD("set_package_cpath", "cpath"), &LuaState::set_package_cpath);
+	ClassDB::bind_static_method(LuaState::get_class_static(), D_METHOD("get_lua_exec_dir"), &LuaState::get_lua_exec_dir);
 
 	// Properties
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "globals", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, LuaTable::get_class_static()), "", "get_globals");

--- a/src/LuaState.cpp
+++ b/src/LuaState.cpp
@@ -29,6 +29,7 @@
 
 #include <godot_cpp/core/binder_common.hpp>
 #include <godot_cpp/classes/file_access.hpp>
+#include <luaconf.h>
 
 namespace luagdextension {
 
@@ -186,7 +187,11 @@ String LuaState::get_package_cpath() const {
 
 void LuaState::set_package_path(const String& path) {
 	if (auto package = lua_state.get<sol::optional<sol::table>>("package")) {
-		package->set("path", path);
+		package->set("path",
+			path.replace(";;", LUA_PATH_SEP LUA_PATH_DEFAULT LUA_PATH_SEP)
+				.rstrip(LUA_PATH_SEP)
+				.lstrip(LUA_PATH_SEP)
+		);
 	}
 	else {
 		ERR_FAIL_MSG("LUA_PACKAGE library is not opened");
@@ -195,7 +200,11 @@ void LuaState::set_package_path(const String& path) {
 
 void LuaState::set_package_cpath(const String& cpath) {
 	if (auto package = lua_state.get<sol::optional<sol::table>>("package")) {
-		package->set("cpath", cpath);
+		package->set("cpath",
+			cpath.replace(";;", LUA_PATH_SEP LUA_CPATH_DEFAULT LUA_PATH_SEP)
+				.rstrip(LUA_PATH_SEP)
+				.lstrip(LUA_PATH_SEP)
+		);
 	}
 	else {
 		ERR_FAIL_MSG("LUA_PACKAGE library is not opened");

--- a/src/LuaState.cpp
+++ b/src/LuaState.cpp
@@ -166,6 +166,42 @@ LuaTable *LuaState::get_registry() const {
 	return memnew(LuaTable(lua_state.registry()));
 }
 
+String LuaState::get_package_path() const {
+	if (auto package = lua_state.get<sol::optional<sol::table>>("package")) {
+		return package->get<String>("path");
+	}
+	else {
+		ERR_FAIL_V_MSG("", "LUA_PACKAGE library is not opened");
+	}
+}
+
+String LuaState::get_package_cpath() const {
+	if (auto package = lua_state.get<sol::optional<sol::table>>("package")) {
+		return package->get<String>("cpath");
+	}
+	else {
+		ERR_FAIL_V_MSG("", "LUA_PACKAGE library is not opened");
+	}
+}
+
+void LuaState::set_package_path(const String& path) {
+	if (auto package = lua_state.get<sol::optional<sol::table>>("package")) {
+		package->set("path", path);
+	}
+	else {
+		ERR_FAIL_MSG("LUA_PACKAGE library is not opened");
+	}
+}
+
+void LuaState::set_package_cpath(const String& cpath) {
+	if (auto package = lua_state.get<sol::optional<sol::table>>("package")) {
+		package->set("cpath", cpath);
+	}
+	else {
+		ERR_FAIL_MSG("LUA_PACKAGE library is not opened");
+	}
+}
+
 LuaState *LuaState::find_lua_state(lua_State *L) {
 	L = sol::main_thread(L);
 	if (LuaState **ptr = valid_states.getptr(L)) {
@@ -219,10 +255,16 @@ void LuaState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("do_file", "filename", "mode", "env"), &LuaState::do_file, DEFVAL(LOAD_MODE_ANY), DEFVAL(nullptr));
 	ClassDB::bind_method(D_METHOD("get_globals"), &LuaState::get_globals);
 	ClassDB::bind_method(D_METHOD("get_registry"), &LuaState::get_registry);
+	ClassDB::bind_method(D_METHOD("get_package_path"), &LuaState::get_package_path);
+	ClassDB::bind_method(D_METHOD("get_package_cpath"), &LuaState::get_package_cpath);
+	ClassDB::bind_method(D_METHOD("set_package_path", "path"), &LuaState::set_package_path);
+	ClassDB::bind_method(D_METHOD("set_package_cpath", "cpath"), &LuaState::set_package_cpath);
 
 	// Properties
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "globals", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, LuaTable::get_class_static()), "", "get_globals");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "registry", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, LuaTable::get_class_static()), "", "get_registry");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "package_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_package_path", "get_package_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "package_cpath", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_package_cpath", "get_package_cpath");
 }
 
 LuaState::operator String() const {

--- a/src/LuaState.hpp
+++ b/src/LuaState.hpp
@@ -113,6 +113,11 @@ public:
 	LuaTable *get_globals() const;
 	LuaTable *get_registry() const;
 
+	String get_package_path() const;
+	String get_package_cpath() const;
+	void set_package_path(const String& path);
+	void set_package_cpath(const String& cpath);
+
 	operator String() const;
 
 	static LuaState *find_lua_state(lua_State *L);

--- a/src/LuaState.hpp
+++ b/src/LuaState.hpp
@@ -120,6 +120,7 @@ public:
 
 	operator String() const;
 
+	static String get_lua_exec_dir();
 	static LuaState *find_lua_state(lua_State *L);
 
 protected:

--- a/src/luaopen/local_paths.cpp
+++ b/src/luaopen/local_paths.cpp
@@ -21,17 +21,12 @@
  */
 
 #include "../LuaTable.hpp"
+#include "../generated/package_searcher.h"
 #include "../utils/convert_godot_lua.hpp"
 #include "../utils/load_fileaccess.hpp"
-#include "sol/forward.hpp"
-#include "sol/load_result.hpp"
 
-#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/file_access.hpp>
-#include <godot_cpp/classes/os.hpp>
-#include <godot_cpp/classes/project_settings.hpp>
-
-#include "../generated/package_searcher.h"
+#include <luaconf.h>
 
 using namespace luagdextension;
 
@@ -43,15 +38,11 @@ static int l_searchpath(lua_State *L) {
 	if (!sep.is_empty()) {
 		name = name.replace(sep, rep);
 	}
-
-	String execdir_repl = Engine::get_singleton()->is_editor_hint()
-		? ProjectSettings::get_singleton()->globalize_path("res://")
-		: OS::get_singleton()->get_executable_path().get_base_dir();
 	
-	PackedStringArray path_list = path.split(";", false);
+	PackedStringArray path_list = path.split(LUA_PATH_SEP, false);
 	PackedStringArray not_found_list;
 	for (const String& path_template : path_list) {
-		String filename = path_template.replace("?", name).replace("!", execdir_repl);
+		String filename = path_template.replace(LUA_PATH_MARK, name);
 		if (FileAccess::file_exists(filename)) {
 			sol::stack::push(L, filename);
 			return 1;

--- a/src/script-language/LuaScriptLanguage.cpp
+++ b/src/script-language/LuaScriptLanguage.cpp
@@ -32,6 +32,7 @@
 #include "../utils/function_wrapper.hpp"
 
 #include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/reg_ex.hpp>
 #include <godot_cpp/classes/reg_ex_match.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
@@ -39,6 +40,19 @@
 #include <godot_cpp/variant/packed_string_array.hpp>
 
 namespace luagdextension {
+
+constexpr char LUA_PATH_SETTING[] = "lua_gdextension/lua_script_language/package_path";
+constexpr char LUA_CPATH_SETTING[] = "lua_gdextension/lua_script_language/package_c_path";
+constexpr char LUA_CPATH_WINDOWS_SETTING[] = "lua_gdextension/lua_script_language/package_c_path.windows";
+constexpr char LUA_CPATH_MACOS_SETTING[] = "lua_gdextension/lua_script_language/package_c_path.macos";
+
+static void add_project_setting(ProjectSettings *project_settings, const String& setting_name, const Variant& initial_value, bool is_basic = false) {
+	if (!project_settings->has_setting(setting_name)) {
+		project_settings->set_setting(setting_name, initial_value);
+	}
+	project_settings->set_initial_value(setting_name, initial_value);
+	project_settings->set_as_basic(setting_name, is_basic);
+}
 
 String LuaScriptLanguage::_get_name() const {
 	return "Lua";
@@ -57,6 +71,17 @@ void LuaScriptLanguage::_init() {
 	LuaScriptMethod::register_lua(state);
 	LuaScriptProperty::register_lua(state);
 	LuaScriptSignal::register_lua(state);
+
+	// Register project settings
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	add_project_setting(project_settings, LUA_PATH_SETTING, "res://?.lua;res://?/init.lua");
+	add_project_setting(project_settings, LUA_CPATH_SETTING, "!/?.so;!/loadall.so");
+	add_project_setting(project_settings, LUA_CPATH_WINDOWS_SETTING, "!/?.dll;!/loadall.dll");
+	add_project_setting(project_settings, LUA_CPATH_MACOS_SETTING, "!/?.dylib;!/loadall.dylib");
+
+	// Apply project settings (package.path, package.cpath)
+	lua_state->set_package_path(project_settings->get_setting_with_override(LUA_PATH_SETTING));
+	lua_state->set_package_cpath(project_settings->get_setting_with_override(LUA_CPATH_SETTING));
 }
 
 String LuaScriptLanguage::_get_type() const {

--- a/test/gdscript_tests/package_path.gd
+++ b/test/gdscript_tests/package_path.gd
@@ -34,13 +34,13 @@ func test_package_path_default() -> bool:
 	lua_state.package_path = ""
 	assert(lua_state.package_path == "")
 	lua_state.package_path = ";;"
-	assert(lua_state.package_path == initial_package_path)
+	assert(lua_state.package_path == initial_package_path, "Expected '%s', got '%s'" % [initial_package_path, lua_state.package_path])
 	lua_state.package_path = "prefix;;"
-	assert(lua_state.package_path == "prefix;" + initial_package_path)
+	assert(lua_state.package_path == "prefix;" + initial_package_path, "Expected '%s', got '%s'" % ["prefix;" + initial_package_path, lua_state.package_path])
 	lua_state.package_path = ";;suffix"
-	assert(lua_state.package_path == initial_package_path + ";suffix")
+	assert(lua_state.package_path == initial_package_path + ";suffix", "Expected '%s', got '%s'" % [initial_package_path + ";suffix", lua_state.package_path])
 	lua_state.package_path = "prefix;;suffix"
-	assert(lua_state.package_path == "prefix;" + initial_package_path + ";suffix")
+	assert(lua_state.package_path == "prefix;" + initial_package_path + ";suffix", "Expected '%s', got '%s'" % ["prefix;" + initial_package_path + ";suffix", lua_state.package_path])
 	return true
 
 
@@ -48,11 +48,11 @@ func test_package_cpath_default() -> bool:
 	lua_state.package_cpath = ""
 	assert(lua_state.package_cpath == "")
 	lua_state.package_cpath = ";;"
-	assert(lua_state.package_cpath == initial_package_cpath)
+	assert(lua_state.package_cpath == initial_package_cpath, "Expected '%s', got '%s'" % [initial_package_path, lua_state.package_path])
 	lua_state.package_cpath = "prefix;;"
-	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath)
+	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath, "Expected '%s', got '%s'" % ["prefix;" + initial_package_cpath, lua_state.package_path])
 	lua_state.package_cpath = ";;suffix"
-	assert(lua_state.package_cpath == initial_package_cpath + ";suffix")
+	assert(lua_state.package_cpath == initial_package_cpath + ";suffix", "Expected '%s', got '%s'" % [initial_package_cpath + ";suffix", lua_state.package_path])
 	lua_state.package_cpath = "prefix;;suffix"
-	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath + ";suffix")
+	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath + ";suffix", "Expected '%s', got '%s'" % ["prefix;" + initial_package_cpath + ";suffix", lua_state.package_path])
 	return true

--- a/test/gdscript_tests/package_path.gd
+++ b/test/gdscript_tests/package_path.gd
@@ -7,7 +7,6 @@ var initial_package_cpath
 
 func _init():
 	lua_state = LuaState.new()
-	lua_state.registry.LUA_NOENV = true
 	lua_state.open_libraries()
 	initial_package_path = lua_state.package_path
 	initial_package_cpath = lua_state.package_cpath
@@ -25,6 +24,7 @@ func test_package_path() -> bool:
 func test_package_cpath() -> bool:
 	var package_cpath = "!/?.so"
 	lua_state.package_cpath = package_cpath
+	package_cpath = package_cpath.replace("!", LuaState.get_lua_exec_dir())
 	assert(lua_state.package_cpath == package_cpath)
 	assert(lua_state.globals.package.path != package_cpath)
 	assert(lua_state.globals.package.cpath == package_cpath)

--- a/test/gdscript_tests/package_path.gd
+++ b/test/gdscript_tests/package_path.gd
@@ -1,0 +1,26 @@
+extends RefCounted
+
+var lua_state
+
+
+func _init():
+	lua_state = LuaState.new()
+	lua_state.open_libraries()
+
+
+func test_package_path() -> bool:
+	var package_path = "res://?.lua"
+	lua_state.package_path = package_path
+	assert(lua_state.package_path == package_path)
+	assert(lua_state.globals.package.path == package_path)
+	assert(lua_state.globals.package.cpath != package_path)
+	return true
+
+
+func test_package_cpath() -> bool:
+	var package_cpath = "!/?.so"
+	lua_state.package_cpath = package_cpath
+	assert(lua_state.package_cpath == package_cpath)
+	assert(lua_state.globals.package.path != package_cpath)
+	assert(lua_state.globals.package.cpath == package_cpath)
+	return true

--- a/test/gdscript_tests/package_path.gd
+++ b/test/gdscript_tests/package_path.gd
@@ -1,11 +1,15 @@
 extends RefCounted
 
 var lua_state
+var initial_package_path
+var initial_package_cpath
 
 
 func _init():
 	lua_state = LuaState.new()
 	lua_state.open_libraries()
+	initial_package_path = lua_state.package_path
+	initial_package_cpath = lua_state.package_cpath
 
 
 func test_package_path() -> bool:
@@ -23,4 +27,32 @@ func test_package_cpath() -> bool:
 	assert(lua_state.package_cpath == package_cpath)
 	assert(lua_state.globals.package.path != package_cpath)
 	assert(lua_state.globals.package.cpath == package_cpath)
+	return true
+
+
+func test_package_path_default() -> bool:
+	lua_state.package_path = ""
+	assert(lua_state.package_path == "")
+	lua_state.package_path = ";;"
+	assert(lua_state.package_path == initial_package_path)
+	lua_state.package_path = "prefix;;"
+	assert(lua_state.package_path == "prefix;" + initial_package_path)
+	lua_state.package_path = ";;suffix"
+	assert(lua_state.package_path == initial_package_path + ";suffix")
+	lua_state.package_path = "prefix;;suffix"
+	assert(lua_state.package_path == "prefix;" + initial_package_path + ";suffix")
+	return true
+
+
+func test_package_cpath_default() -> bool:
+	lua_state.package_cpath = ""
+	assert(lua_state.package_cpath == "")
+	lua_state.package_cpath = ";;"
+	assert(lua_state.package_cpath == initial_package_cpath)
+	lua_state.package_cpath = "prefix;;"
+	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath)
+	lua_state.package_cpath = ";;suffix"
+	assert(lua_state.package_cpath == initial_package_cpath + ";suffix")
+	lua_state.package_cpath = "prefix;;suffix"
+	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath + ";suffix")
 	return true

--- a/test/gdscript_tests/package_path.gd
+++ b/test/gdscript_tests/package_path.gd
@@ -7,6 +7,7 @@ var initial_package_cpath
 
 func _init():
 	lua_state = LuaState.new()
+	lua_state.registry.LUA_NOENV = true
 	lua_state.open_libraries()
 	initial_package_path = lua_state.package_path
 	initial_package_cpath = lua_state.package_cpath

--- a/test/gdscript_tests/package_path.gd
+++ b/test/gdscript_tests/package_path.gd
@@ -35,13 +35,13 @@ func test_package_path_default() -> bool:
 	lua_state.package_path = ""
 	assert(lua_state.package_path == "")
 	lua_state.package_path = ";;"
-	assert(lua_state.package_path == initial_package_path, "Expected '%s', got '%s'" % [initial_package_path, lua_state.package_path])
+	assert(lua_state.package_path.replace("\\", "/") == initial_package_path.replace("\\", "/"), "Expected '%s', got '%s'" % [initial_package_path.replace("\\", "/"), lua_state.package_path.replace("\\", "/")])
 	lua_state.package_path = "prefix;;"
-	assert(lua_state.package_path == "prefix;" + initial_package_path, "Expected '%s', got '%s'" % ["prefix;" + initial_package_path, lua_state.package_path])
+	assert(lua_state.package_path.replace("\\", "/") == "prefix;" + initial_package_path.replace("\\", "/"), "Expected '%s', got '%s'" % ["prefix;" + initial_package_path.replace("\\", "/"), lua_state.package_path.replace("\\", "/")])
 	lua_state.package_path = ";;suffix"
-	assert(lua_state.package_path == initial_package_path + ";suffix", "Expected '%s', got '%s'" % [initial_package_path + ";suffix", lua_state.package_path])
+	assert(lua_state.package_path.replace("\\", "/") == initial_package_path.replace("\\", "/") + ";suffix", "Expected '%s', got '%s'" % [initial_package_path.replace("\\", "/") + ";suffix", lua_state.package_path.replace("\\", "/")])
 	lua_state.package_path = "prefix;;suffix"
-	assert(lua_state.package_path == "prefix;" + initial_package_path + ";suffix", "Expected '%s', got '%s'" % ["prefix;" + initial_package_path + ";suffix", lua_state.package_path])
+	assert(lua_state.package_path.replace("\\", "/") == "prefix;" + initial_package_path.replace("\\", "/") + ";suffix", "Expected '%s', got '%s'" % ["prefix;" + initial_package_path.replace("\\", "/") + ";suffix", lua_state.package_path.replace("\\", "/")])
 	return true
 
 
@@ -49,11 +49,11 @@ func test_package_cpath_default() -> bool:
 	lua_state.package_cpath = ""
 	assert(lua_state.package_cpath == "")
 	lua_state.package_cpath = ";;"
-	assert(lua_state.package_cpath == initial_package_cpath, "Expected '%s', got '%s'" % [initial_package_path, lua_state.package_path])
+	assert(lua_state.package_cpath.replace("\\", "/") == initial_package_cpath.replace("\\", "/"), "Expected '%s', got '%s'" % [initial_package_path.replace("\\", "/"), lua_state.package_path.replace("\\", "/")])
 	lua_state.package_cpath = "prefix;;"
-	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath, "Expected '%s', got '%s'" % ["prefix;" + initial_package_cpath, lua_state.package_path])
+	assert(lua_state.package_cpath.replace("\\", "/") == "prefix;" + initial_package_cpath.replace("\\", "/"), "Expected '%s', got '%s'" % ["prefix;" + initial_package_cpath.replace("\\", "/"), lua_state.package_path.replace("\\", "/")])
 	lua_state.package_cpath = ";;suffix"
-	assert(lua_state.package_cpath == initial_package_cpath + ";suffix", "Expected '%s', got '%s'" % [initial_package_cpath + ";suffix", lua_state.package_path])
+	assert(lua_state.package_cpath.replace("\\", "/") == initial_package_cpath.replace("\\", "/") + ";suffix", "Expected '%s', got '%s'" % [initial_package_cpath.replace("\\", "/") + ";suffix", lua_state.package_path.replace("\\", "/")])
 	lua_state.package_cpath = "prefix;;suffix"
-	assert(lua_state.package_cpath == "prefix;" + initial_package_cpath + ";suffix", "Expected '%s', got '%s'" % ["prefix;" + initial_package_cpath + ";suffix", lua_state.package_path])
+	assert(lua_state.package_cpath.replace("\\", "/") == "prefix;" + initial_package_cpath.replace("\\", "/") + ";suffix", "Expected '%s', got '%s'" % ["prefix;" + initial_package_cpath.replace("\\", "/") + ";suffix", lua_state.package_path.replace("\\", "/")])
 	return true

--- a/test/gdscript_tests/package_path.gd.uid
+++ b/test/gdscript_tests/package_path.gd.uid
@@ -1,0 +1,1 @@
+uid://bsfmpr4en0xje


### PR DESCRIPTION
This PR adds:
- `LuaState.package_path` and `LuaState.package_cpath` properties for accessing the value of Lua's [`package.path`](https://www.lua.org/manual/5.4/manual.html#pdf-package.path) and [`package.cpath`](https://www.lua.org/manual/5.4/manual.html#pdf-package.cpath)
- Advanced project settings for setting the `LuaScriptLanguage` state's `package_path` and `package_cpath` properties