### PR TITLE
Add support for calling Callables in Lua without opening GODOT_VARIANT library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   Otherwise, it returns the base directory of the executable.
 - Advanced project settings for setting the `LuaScriptLanguage` state's `package_path` and `package_cpath` properties
 - `LuaState.are_libraries_opened` method for checking if a subset of libraries were already opened
+- `LuaState.create_function` method for creating a `LuaFunction` from a `Callable`
 
 ### Changed
 - The GDExtension is now marked as reloadable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - The GDExtension is now marked as reloadable
 - Renamed `LuaCoroutine::LuaCoroutineStatus` to `LuaCoroutine::Status`
 - `LuaState.load_file` and `LuaState.do_file` now receive the load mode instead of buffer size
+- `Callable` values when passed to Lua are wrapped as Lua functions when `GODOT_VARIANT` library is not opened, making it possible to call them in sandboxed environments
 
 ### Removed
 - `VariantType::has_static_method` internal method

--- a/src/LuaState.cpp
+++ b/src/LuaState.cpp
@@ -21,6 +21,7 @@
  */
 #include "LuaState.hpp"
 
+#include "LuaFunction.hpp"
 #include "LuaTable.hpp"
 #include "luaopen/godot.hpp"
 #include "utils/_G_metatable.hpp"
@@ -142,6 +143,11 @@ bool LuaState::are_libraries_opened(BitField<Library> libraries) const {
 
 Ref<LuaTable> LuaState::create_table(const Dictionary& initial_values) {
 	return memnew(LuaTable(to_table(lua_state, initial_values)));
+}
+
+Ref<LuaFunction> LuaState::create_function(const Callable& callable) {
+	ERR_FAIL_COND_V(!callable.is_valid(), nullptr);
+	return memnew(LuaFunction(to_lua_function(lua_state, callable)));
 }
 
 Variant LuaState::load_buffer(const PackedByteArray& chunk, const String& chunkname, LoadMode mode, LuaTable *env) {
@@ -272,6 +278,7 @@ void LuaState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open_libraries", "libraries"), &LuaState::open_libraries, DEFVAL(BitField<Library>(ALL_LIBS)));
 	ClassDB::bind_method(D_METHOD("are_libraries_opened", "libraries"), &LuaState::are_libraries_opened);
 	ClassDB::bind_method(D_METHOD("create_table", "initial_values"), &LuaState::create_table, DEFVAL(Dictionary()));
+	ClassDB::bind_method(D_METHOD("create_function", "callable"), &LuaState::create_function);
 	ClassDB::bind_method(D_METHOD("load_buffer", "chunk", "chunkname", "mode", "env"), &LuaState::load_buffer, DEFVAL(""), DEFVAL(LOAD_MODE_ANY), DEFVAL(nullptr));
 	ClassDB::bind_method(D_METHOD("load_string", "chunk", "chunkname", "env"), &LuaState::load_string, DEFVAL(""), DEFVAL(nullptr));
 	ClassDB::bind_method(D_METHOD("load_file", "filename", "mode", "env"), &LuaState::load_file, DEFVAL(LOAD_MODE_ANY), DEFVAL(nullptr));

--- a/src/LuaState.hpp
+++ b/src/LuaState.hpp
@@ -31,6 +31,7 @@ using namespace godot;
 
 namespace luagdextension {
 
+class LuaFunction;
 class LuaTable;
 
 class LuaState : public RefCounted {
@@ -104,6 +105,7 @@ public:
 	bool are_libraries_opened(BitField<Library> libraries) const;
 
 	Ref<LuaTable> create_table(const Dictionary& initial_values = {});
+	Ref<LuaFunction> create_function(const Callable& callable);
 	Variant load_buffer(const PackedByteArray& chunk, const String& chunkname = "", LoadMode mode = LOAD_MODE_ANY, LuaTable *env = nullptr);
 	Variant load_string(const String& chunk, const String& chunkname = "", LuaTable *env = nullptr);
 	Variant load_file(const String& filename, LoadMode mode = LOAD_MODE_ANY, LuaTable *env = nullptr);

--- a/src/luaopen/variant.cpp
+++ b/src/luaopen/variant.cpp
@@ -163,9 +163,7 @@ sol::object variant__call(sol::this_state state, const Variant& variant, sol::va
 	if (variant.get_type() != Variant::CALLABLE) {
 		luaL_error(state, "attempt to call a %s value", get_type_name(variant).ascii().get_data());
 	}
-	Callable callable = variant;
-	VariantArguments var_args = args;
-	Variant result = callable.callv(var_args.get_array());
+	Variant result = callable_call(variant, args);
 	return to_lua(state, result);
 }
 

--- a/src/utils/convert_godot_lua.cpp
+++ b/src/utils/convert_godot_lua.cpp
@@ -173,9 +173,22 @@ sol::stack_object lua_push(lua_State *lua_state, const Variant& value) {
 					break;
 				}
 			}
-			// fallthrough
+			goto push_as_variant;
+			
+		case Variant::CALLABLE:
+			if (LuaState *gdlua = LuaState::find_lua_state(lua_state); gdlua->are_libraries_opened(LuaState::GODOT_VARIANT))
+			{
+				goto push_as_variant;
+			}
+			else {
+				// If GODOT_VARIANT library is not opened in this lua_State, push Callable wrapped in a Lua function
+				lua_push_function(lua_state, (Callable) value);
+				break;
+			}
+
+push_as_variant:
 		default:
-			sol::stack::push(lua_state, value);
+			sol::stack::push_userdata(lua_state, value);
 			break;
 	}
 	return sol::stack_object(lua_state, -1);
@@ -190,7 +203,7 @@ sol::object to_lua(lua_State *lua_state, const Variant& value) {
 Array to_array(const sol::variadic_args& args) {
 	Array arr;
 	for (auto it : args) {
-		arr.append(to_variant(it.get<sol::object>()));
+		arr.append(to_variant(it.get<sol::stack_object>()));
 	}
 	return arr;
 }
@@ -231,13 +244,24 @@ static int callable_closure(lua_State *L) {
 	lua_push(L, result);
 	return 1;
 }
-sol::protected_function to_lua_function(sol::state_view& state, const Callable& callable) {
-	StackTopChecker topcheck(state);
-	lua_push(state, callable);
-	lua_pushcclosure(state, callable_closure, 1);
-	sol::protected_function result = sol::stack_protected_function(state, -1);
-	lua_pop(state, 1);
+void lua_push_function(lua_State *L, const Callable& callable) {
+	ERR_FAIL_COND(!callable.is_valid());
+	StackTopChecker topcheck(L, 1);
+	sol::stack::push_userdata(L, (Variant) callable);
+	lua_pushcclosure(L, callable_closure, 1);
+}
+
+sol::protected_function to_lua_function(lua_State *L, const Callable& callable) {
+	ERR_FAIL_COND_V(!callable.is_valid(), nullptr);
+	StackTopChecker topcheck(L);
+	lua_push_function(L, callable);
+	sol::protected_function result = sol::stack_protected_function(L, -1);
+	lua_pop(L, 1);
 	return result;
+}
+
+Variant callable_call(const Callable& callable, const sol::variadic_args& args) {
+	return callable.callv(VariantArguments(args).get_array());
 }
 
 sol::object variant_static_call_string_name(sol::this_state state, Variant::Type type, const StringName& method, const sol::variadic_args& args) {

--- a/src/utils/convert_godot_lua.hpp
+++ b/src/utils/convert_godot_lua.hpp
@@ -38,15 +38,17 @@ Variant to_variant(const sol::stack_proxy_base& object);
 Variant to_variant(const sol::protected_function_result& function_result);
 Variant to_variant(const sol::load_result& load_result);
 Variant to_variant(lua_State *L, int index);
-sol::stack_object lua_push(lua_State *lua_state, const Variant& value);
-sol::object to_lua(lua_State *lua_state, const Variant& value);
+sol::stack_object lua_push(lua_State *L, const Variant& value);
+sol::object to_lua(lua_State *L, const Variant& value);
 
 Array to_array(const sol::variadic_args& args);
 Array to_array(const sol::table& table);
 Dictionary to_dictionary(const sol::table& table);
 sol::table to_table(sol::state_view& state, const Dictionary& dictionary);
 
-sol::protected_function to_lua_function(sol::state_view& state, const Callable& callable);
+void lua_push_function(lua_State *L, const Callable& callable);
+sol::protected_function to_lua_function(lua_State *L, const Callable& callable);
+Variant callable_call(const Callable& callable, const sol::variadic_args& args);
 
 sol::object variant_static_call_string_name(sol::this_state state, Variant::Type type, const StringName& method, const sol::variadic_args& args);
 sol::object variant_call_string_name(sol::this_state state, Variant& variant, const StringName& method, const sol::variadic_args& args);

--- a/src/utils/convert_godot_lua.hpp
+++ b/src/utils/convert_godot_lua.hpp
@@ -46,6 +46,8 @@ Array to_array(const sol::table& table);
 Dictionary to_dictionary(const sol::table& table);
 sol::table to_table(sol::state_view& state, const Dictionary& dictionary);
 
+sol::protected_function to_lua_function(sol::state_view& state, const Callable& callable);
+
 sol::object variant_static_call_string_name(sol::this_state state, Variant::Type type, const StringName& method, const sol::variadic_args& args);
 sol::object variant_call_string_name(sol::this_state state, Variant& variant, const StringName& method, const sol::variadic_args& args);
 sol::object variant_call(sol::this_state state, Variant& variant, const char *method, const sol::variadic_args& args);

--- a/src/utils/stack_top_checker.cpp
+++ b/src/utils/stack_top_checker.cpp
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+#ifdef DEBUG_ENABLED
+
 #include <godot_cpp/core/error_macros.hpp>
 
 #include "custom_sol.hpp"
@@ -27,19 +29,20 @@
 
 namespace luagdextension {
 
-StackTopChecker::StackTopChecker(lua_State *L)
+StackTopChecker::StackTopChecker(lua_State *L, int expected_extra_values)
 	: L(L)
+	, expected_extra_values(expected_extra_values)
 	, previous_top(lua_gettop(L))
 {
 }
 
 StackTopChecker::~StackTopChecker() {
-#ifdef DEBUG_ENABLED
 	int top = lua_gettop(L);
-	if (top != previous_top) {
-		ERR_PRINT(String("Invalid stack top, expected %d, found %d") % Array::make(previous_top, top));
+	if (top != previous_top + expected_extra_values) {
+		ERR_PRINT(String("Invalid stack top, expected %d, found %d") % Array::make(previous_top + expected_extra_values, top));
 	}
-#endif
 }
 
 }
+
+#endif

--- a/src/utils/stack_top_checker.hpp
+++ b/src/utils/stack_top_checker.hpp
@@ -27,15 +27,26 @@ typedef struct lua_State lua_State;
 
 namespace luagdextension {
 
+#ifdef DEBUG_ENABLED
+
 class StackTopChecker {
 public:
-	StackTopChecker(lua_State *L);
+	StackTopChecker(lua_State *L, int expected_extra_values = 0);
 	~StackTopChecker();
 
 private:
 	lua_State *L;
+	int expected_extra_values;
 	int previous_top;
 };
+
+#else
+
+struct StackTopChecker {
+	StackTopChecker(lua_State *L, int expected_extra_values = 0) {}
+};
+
+#endif
 
 }
 

--- a/test/gdscript_tests/LuaFunction_invoke.gd
+++ b/test/gdscript_tests/LuaFunction_invoke.gd
@@ -47,6 +47,16 @@ func test_callable() -> bool:
 	return true
 
 
+func test_create_function() -> bool:
+	var callable = func(arg1):
+		return arg1
+	var lua_function = lua_state.create_function(callable)
+	assert(lua_function is LuaFunction)
+	assert(_test_call(lua_function, [1]) == 1)
+	assert(_test_call(lua_function, [[]]) == [])
+	return true
+
+
 func _test_call(f: LuaFunction, args: Array = []):
 	var result = f.invokev(args)
 	if result is LuaError:

--- a/test/gdscript_tests/sandboxed_callable.gd
+++ b/test/gdscript_tests/sandboxed_callable.gd
@@ -1,0 +1,25 @@
+extends RefCounted
+
+
+func test_sandboxed_callable() -> bool:
+	var sum = func(arg1, arg2):
+		return arg1 + arg2
+	
+	var lua_state = LuaState.new()
+	lua_state.globals["sum"] = sum
+	var result = lua_state.do_string("return sum(1, 2)")
+	assert(result == 3)
+	return true
+
+
+func test_variant_callable() -> bool:
+	var sum = func(arg1, arg2):
+		return arg1 + arg2
+	
+	var lua_state = LuaState.new()
+	lua_state.open_libraries()
+	lua_state.globals["sum"] = sum
+	var result = lua_state.do_string("return sum(1, 2)")
+	assert(result == 3)
+	return true
+	

--- a/test/gdscript_tests/sandboxed_callable.gd.uid
+++ b/test/gdscript_tests/sandboxed_callable.gd.uid
@@ -1,0 +1,1 @@
+uid://xj2dg6xbyg22


### PR DESCRIPTION
This PR also adds the `LuaState.create_function(callable: Callable) -> LuaFunction` method.
Implements #55.