### PR TITLE
Reuse LuaObject instances when referencing a known Lua object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## [Unreleased](https://github.com/gilzoide/lua-gdextension/compare/0.3.0...HEAD)
+### Changed
+- `LuaObject` instances are reused when wrapping the same Lua object, so that `==` and `is_same` can be used properly
 
 
 ## [0.3.0](https://github.com/gilzoide/lua-gdextension/releases/tag/0.3.0)

--- a/src/LuaObject.cpp
+++ b/src/LuaObject.cpp
@@ -44,4 +44,6 @@ String LuaObject::_to_string() const {
 	return String("[%s:0x%x]") % Array::make(get_class(), get_pointer_value());
 }
 
+HashMap<const void *, LuaObject *> LuaObject::known_objects;
+
 }

--- a/src/LuaState.cpp
+++ b/src/LuaState.cpp
@@ -175,11 +175,11 @@ Variant LuaState::do_file(const String& filename, LoadMode mode, LuaTable *env) 
 }
 
 LuaTable *LuaState::get_globals() const {
-	return memnew(LuaTable(lua_state.globals()));
+	return LuaObject::wrap_object<LuaTable>(lua_state.globals());
 }
 
 LuaTable *LuaState::get_registry() const {
-	return memnew(LuaTable(lua_state.registry()));
+	return LuaObject::wrap_object<LuaTable>(lua_state.registry());
 }
 
 String LuaState::get_package_path() const {

--- a/src/utils/convert_godot_lua.cpp
+++ b/src/utils/convert_godot_lua.cpp
@@ -62,9 +62,9 @@ Variant to_variant(const sol::basic_object<ref_t>& object) {
 			return object.template as<double>();
 
 		case sol::type::table:
-			return memnew(LuaTable(object.template as<sol::table>()));
+			return LuaObject::wrap_object<LuaTable>(object);
 
-		case sol::type::userdata: {
+		case sol::type::userdata:
 			if (object.template is<Variant>()) {
 				GDExtensionVariantPtr variant_ptr = object.template as<Variant *>();
 				return Variant(variant_ptr);
@@ -74,18 +74,17 @@ Variant to_variant(const sol::basic_object<ref_t>& object) {
 				return cls.get_name();
 			}
 			else {
-				return memnew(LuaUserdata(object.template as<sol::userdata>()));
+				return LuaObject::wrap_object<LuaUserdata>(object);
 			}
-		}
 
 		case sol::type::thread:
-			return memnew(LuaCoroutine(object.template as<sol::thread>()));
+			return LuaObject::wrap_object<LuaCoroutine>(object);
 
 		case sol::type::function:
-			return memnew(LuaFunction(object.template as<sol::protected_function>()));
+			return LuaObject::wrap_object<LuaFunction>(object);
 
 		case sol::type::lightuserdata:
-			return memnew(LuaLightUserdata(object.template as<sol::lightuserdata>()));
+			return LuaObject::wrap_object<LuaLightUserdata>(object);
 
 		case sol::type::none:
 		case sol::type::nil:
@@ -132,7 +131,7 @@ Variant to_variant(const sol::load_result& load_result) {
 		return memnew(LuaError(load_result));
 	}
 	else {
-		return memnew(LuaFunction(load_result.get<sol::protected_function>()));
+		return LuaObject::wrap_object<LuaFunction>(load_result.get<sol::protected_function>());
 	}
 }
 

--- a/test/gdscript_tests/lua_known_objects.gd
+++ b/test/gdscript_tests/lua_known_objects.gd
@@ -1,0 +1,39 @@
+extends RefCounted
+
+
+var lua_state: LuaState
+
+
+func _init():
+	lua_state = LuaState.new()
+	lua_state.open_libraries()
+
+
+func test_is_same_table() -> bool:
+	lua_state.do_string("""
+		t = {}
+	""")
+	var t = lua_state.globals["t"]
+	assert(lua_state.globals["t"] == t)
+	assert(is_same(lua_state.globals["t"], t))
+	return true
+
+
+func test_is_same_coroutine() -> bool:
+	lua_state.do_string("""
+		c = coroutine.create(function() end)
+	""")
+	var c = lua_state.globals["c"]
+	assert(lua_state.globals["c"] == c)
+	assert(is_same(lua_state.globals["c"], c))
+	return true
+
+
+func test_is_same_function() -> bool:
+	lua_state.do_string("""
+		f = function() end
+	""")
+	var f = lua_state.globals["f"]
+	assert(lua_state.globals["f"] == f)
+	assert(is_same(lua_state.globals["f"], f))
+	return true

--- a/test/gdscript_tests/lua_known_objects.gd.uid
+++ b/test/gdscript_tests/lua_known_objects.gd.uid
@@ -1,0 +1,1 @@
+uid://b2dvt4cmyl65s


### PR DESCRIPTION
This way we can properly test for equality between references to the same Lua object, since there will be only a single instance for each Lua object in Godot.