### PR TITLE
Add `await` function to Lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 ## [Unreleased](https://github.com/gilzoide/lua-gdextension/compare/0.3.0...HEAD)
+### Added
+- `LuaCoroutine.completed` and `LuaCoroutine.failed` signals
+- `await` function similar to GDScript's, allowing coroutines to yield and resume automatically when a signal is emitted
+
 ### Changed
 - `LuaObject` instances are reused when wrapping the same Lua object, so that `==` and `is_same` can be used properly
+- The following methods of LuaScripts run in pooled coroutines, so that `await` can be used in them: regular method calls, setter functions, `_init`, `_notification`
 
 
 ## [0.3.0](https://github.com/gilzoide/lua-gdextension/releases/tag/0.3.0)

--- a/src/LuaCoroutine.cpp
+++ b/src/LuaCoroutine.cpp
@@ -51,17 +51,16 @@ LuaCoroutine::Status LuaCoroutine::get_status() const {
 }
 
 Variant LuaCoroutine::resume(const Variant **args, GDExtensionInt arg_count, GDExtensionCallError& error) {
-	ERR_FAIL_COND_V_MSG(lua_object.status() != sol::thread_status::yielded, Variant(), "Cannot resume a coroutine that is not suspended.");
 	error.error = GDEXTENSION_CALL_OK;
 	return _resume(VariantArguments(args, arg_count), true);
 }
 
 Variant LuaCoroutine::resumev(const Array& args) {
-	ERR_FAIL_COND_V_MSG(lua_object.status() != sol::thread_status::yielded, Variant(), "Cannot resume a coroutine that is not suspended.");
 	return _resume(VariantArguments(args), true);
 }
 
 Variant LuaCoroutine::_resume(const VariantArguments& args, bool return_lua_error) {
+	ERR_FAIL_COND_V_MSG(lua_object.status() != sol::thread_status::yielded, Variant(), "Cannot resume a coroutine that is not suspended.");
 	sol::protected_function_result function_result = _resume(lua_object.thread_state(), args);
 	Variant ret = to_variant(function_result, true);
 	if (function_result.status() == sol::call_status::ok) {

--- a/src/LuaCoroutine.cpp
+++ b/src/LuaCoroutine.cpp
@@ -51,6 +51,7 @@ LuaCoroutine::Status LuaCoroutine::get_status() const {
 
 Variant LuaCoroutine::resume(const Variant **args, GDExtensionInt arg_count, GDExtensionCallError& error) {
 	ERR_FAIL_COND_V_MSG(lua_object.status() != sol::thread_status::yielded, Variant(), "Cannot resume a coroutine that is not yielded.");
+	error.error = GDEXTENSION_CALL_OK;
 	return _resume(VariantArguments(args, arg_count));
 }
 

--- a/src/LuaCoroutine.cpp
+++ b/src/LuaCoroutine.cpp
@@ -80,6 +80,17 @@ Variant LuaCoroutine::_resume(const VariantArguments& args, bool return_lua_erro
 	return ret;
 }
 
+Variant LuaCoroutine::invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error) {
+	Ref<LuaCoroutine> coroutine = LuaCoroutine::create(f);
+	Variant result = coroutine->_resume(args, return_lua_error);
+	if (coroutine->get_status() == LuaCoroutine::STATUS_YIELD) {
+		return coroutine;
+	}
+	else {
+		return result;
+	}
+}
+
 void LuaCoroutine::_bind_methods() {
 	BIND_ENUM_CONSTANT(STATUS_OK);
 	BIND_ENUM_CONSTANT(STATUS_YIELD);

--- a/src/LuaCoroutine.cpp
+++ b/src/LuaCoroutine.cpp
@@ -41,7 +41,7 @@ LuaCoroutine *LuaCoroutine::create(const sol::function& function) {
 }
 
 LuaCoroutine *LuaCoroutine::create(LuaFunction *function) {
-	ERR_FAIL_COND_V_MSG(!function, nullptr, "Function cannot be null");
+	ERR_FAIL_COND_V_MSG(function == nullptr, nullptr, "Function cannot be null");
 	return create(function->get_function());
 }
 

--- a/src/LuaCoroutine.hpp
+++ b/src/LuaCoroutine.hpp
@@ -64,6 +64,7 @@ protected:
 	
 private:
 	Variant _resume(const VariantArguments& args, bool return_lua_error);
+	static sol::protected_function_result _resume(lua_State *L, const VariantArguments& args);
 };
 
 }

--- a/src/LuaCoroutine.hpp
+++ b/src/LuaCoroutine.hpp
@@ -56,12 +56,10 @@ public:
 	Status get_status() const;
 	Variant resumev(const Array& args);
 	Variant resume(const Variant **argv, GDExtensionInt argc, GDExtensionCallError& error);
+	Variant _resume(const VariantArguments& args, bool return_lua_error);
 
 protected:
 	static void _bind_methods();
-
-private:
-	Variant _resume(const VariantArguments& args);
 };
 
 }

--- a/src/LuaCoroutine.hpp
+++ b/src/LuaCoroutine.hpp
@@ -58,6 +58,8 @@ public:
 	Variant resume(const Variant **argv, GDExtensionInt argc, GDExtensionCallError& error);
 	Variant _resume(const VariantArguments& args, bool return_lua_error);
 
+	static Variant invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error);
+
 protected:
 	static void _bind_methods();
 };

--- a/src/LuaCoroutine.hpp
+++ b/src/LuaCoroutine.hpp
@@ -56,12 +56,14 @@ public:
 	Status get_status() const;
 	Variant resumev(const Array& args);
 	Variant resume(const Variant **argv, GDExtensionInt argc, GDExtensionCallError& error);
-	Variant _resume(const VariantArguments& args, bool return_lua_error);
 
 	static Variant invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error);
 
 protected:
 	static void _bind_methods();
+	
+private:
+	Variant _resume(const VariantArguments& args, bool return_lua_error);
 };
 
 }

--- a/src/LuaCoroutine.hpp
+++ b/src/LuaCoroutine.hpp
@@ -59,6 +59,9 @@ public:
 
 protected:
 	static void _bind_methods();
+
+private:
+	Variant _resume(const VariantArguments& args);
 };
 
 }

--- a/src/LuaFunction.cpp
+++ b/src/LuaFunction.cpp
@@ -22,7 +22,6 @@
 #include "LuaFunction.hpp"
 
 #include "LuaError.hpp"
-#include "script-language/LuaScriptInstance.hpp"
 #include "utils/VariantArguments.hpp"
 #include "utils/convert_godot_lua.hpp"
 
@@ -52,29 +51,16 @@ void LuaFunction::_bind_methods() {
 }
 
 Variant LuaFunction::invokev(const Array& args) {
-	return invokev_lua(lua_object, args, true);
+	return invoke_lua(lua_object, args, true);
 }
 
 Variant LuaFunction::invoke(const Variant **args, GDExtensionInt arg_count, GDExtensionCallError &error) {
 	error.error = GDEXTENSION_CALL_OK;
-	return invoke_lua(lua_object, args, arg_count, true);
+	return invoke_lua(lua_object, VariantArguments(args, arg_count), true);
 }
 
-Variant LuaFunction::invoke_lua(const sol::protected_function& f, const Variant **args, GDExtensionInt arg_count, bool return_lua_error) {
-	lua_State *L = f.lua_state();
-	sol::protected_function_result result = f.call(VariantArguments(args, arg_count));
-	return result_value(result, return_lua_error);
-}
-
-Variant LuaFunction::invoke_method_lua(const sol::protected_function& f, const Variant& self, const Variant **args, GDExtensionInt arg_count, bool return_lua_error) {
-	lua_State *L = f.lua_state();
-	sol::protected_function_result result = f.call(VariantArguments(self, args, arg_count));
-	return result_value(result, return_lua_error);
-}
-
-Variant LuaFunction::invokev_lua(const sol::protected_function& f, const Array& args, bool return_lua_error) {
-	lua_State *L = f.lua_state();
-	sol::protected_function_result result = f.call(VariantArguments(args));
+Variant LuaFunction::invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error) {
+	sol::protected_function_result result = f.call(args);
 	return result_value(result, return_lua_error);
 }
 

--- a/src/LuaFunction.cpp
+++ b/src/LuaFunction.cpp
@@ -29,16 +29,6 @@
 
 namespace luagdextension {
 
-static Variant result_value(const sol::protected_function_result& result, bool return_lua_error) {
-	if (!return_lua_error && !result.valid()) {
-		ERR_PRINT(LuaError::extract_message(result));
-		return Variant();
-	}
-	else {
-		return to_variant(result);
-	}
-}
-
 LuaFunction::LuaFunction() : LuaObjectSubclass() {}
 LuaFunction::LuaFunction(sol::protected_function&& function) : LuaObjectSubclass(function) {}
 LuaFunction::LuaFunction(const sol::protected_function& function) : LuaObjectSubclass(function) {}
@@ -61,7 +51,7 @@ Variant LuaFunction::invoke(const Variant **args, GDExtensionInt arg_count, GDEx
 
 Variant LuaFunction::invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error) {
 	sol::protected_function_result result = f.call(args);
-	return result_value(result, return_lua_error);
+	return to_variant(result, return_lua_error);
 }
 
 Callable LuaFunction::to_callable() const {

--- a/src/LuaFunction.cpp
+++ b/src/LuaFunction.cpp
@@ -21,7 +21,6 @@
  */
 #include "LuaFunction.hpp"
 
-#include "LuaError.hpp"
 #include "utils/VariantArguments.hpp"
 #include "utils/convert_godot_lua.hpp"
 
@@ -37,7 +36,6 @@ void LuaFunction::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("invokev", "arg_array"), &LuaFunction::invokev);
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "invoke", &LuaFunction::invoke);
 	ClassDB::bind_method(D_METHOD("to_callable"), &LuaFunction::to_callable);
-
 }
 
 Variant LuaFunction::invokev(const Array& args) {

--- a/src/LuaFunction.hpp
+++ b/src/LuaFunction.hpp
@@ -28,6 +28,8 @@ using namespace godot;
 
 namespace luagdextension {
 
+class VariantArguments;
+
 class LuaFunction : public LuaObjectSubclass<sol::protected_function> {
 	GDCLASS(LuaFunction, LuaObject);
 
@@ -39,9 +41,7 @@ public:
 	Variant invokev(const Array& args);
 	Variant invoke(const Variant **args, GDExtensionInt arg_count, GDExtensionCallError &error);
 
-	static Variant invoke_lua(const sol::protected_function& f, const Variant **args, GDExtensionInt arg_count, bool return_lua_error);
-	static Variant invoke_method_lua(const sol::protected_function& f, const Variant& self, const Variant **args, GDExtensionInt arg_count, bool return_lua_error);
-	static Variant invokev_lua(const sol::protected_function& f, const Array& args, bool return_lua_error);
+	static Variant invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error);
 
 	Callable to_callable() const;
 

--- a/src/LuaTable.cpp
+++ b/src/LuaTable.cpp
@@ -190,7 +190,7 @@ bool LuaTable::_set(const StringName& property_name, const Variant& value) {
 String LuaTable::_to_string() const {
 	auto tostring_result = call_metamethod(lua_object, sol::meta_function::to_string);
 	if (tostring_result.has_value()) {
-		return to_variant(tostring_result.value());
+		return to_variant(tostring_result.value(), false);
 	}
 	else {
 		return LuaObjectSubclass::_to_string();

--- a/src/script-language/LuaScript.cpp
+++ b/src/script-language/LuaScript.cpp
@@ -29,6 +29,7 @@
 #include "../LuaFunction.hpp"
 #include "../LuaState.hpp"
 #include "../LuaTable.hpp"
+#include "../utils/VariantArguments.hpp"
 #include "../utils/convert_godot_lua.hpp"
 
 #include "gdextension_interface.h"
@@ -278,7 +279,7 @@ Variant LuaScript::_new(const Variant **args, GDExtensionInt arg_count, GDExtens
 		obj->set_script(this);
 	}
 	if (const LuaScriptMethod *_init = metadata.methods.getptr("_init")) {
-		LuaFunction::invoke_method_lua(_init->method, new_instance, args, arg_count, false);
+		LuaFunction::invoke_lua(_init->method, VariantArguments(new_instance, args, arg_count), false);
 	}
 	return new_instance;
 }

--- a/src/script-language/LuaScript.cpp
+++ b/src/script-language/LuaScript.cpp
@@ -25,6 +25,7 @@
 #include "LuaScriptLanguage.hpp"
 #include "LuaScriptMethod.hpp"
 #include "LuaScriptProperty.hpp"
+#include "../LuaCoroutine.hpp"
 #include "../LuaError.hpp"
 #include "../LuaFunction.hpp"
 #include "../LuaState.hpp"
@@ -279,7 +280,7 @@ Variant LuaScript::_new(const Variant **args, GDExtensionInt arg_count, GDExtens
 		obj->set_script(this);
 	}
 	if (const LuaScriptMethod *_init = metadata.methods.getptr("_init")) {
-		LuaFunction::invoke_lua(_init->method, VariantArguments(new_instance, args, arg_count), false);
+		LuaCoroutine::invoke_lua(_init->method, VariantArguments(new_instance, args, arg_count), false);
 	}
 	return new_instance;
 }

--- a/src/script-language/LuaScriptInstance.cpp
+++ b/src/script-language/LuaScriptInstance.cpp
@@ -30,6 +30,7 @@
 #include "../LuaError.hpp"
 #include "../LuaFunction.hpp"
 #include "../LuaTable.hpp"
+#include "../utils/VariantArguments.hpp"
 #include "../utils/convert_godot_lua.hpp"
 
 namespace luagdextension {
@@ -54,7 +55,7 @@ LuaScriptInstance::~LuaScriptInstance() {
 GDExtensionBool set_func(LuaScriptInstance *p_instance, const StringName *p_name, const Variant *p_value) {
 	// 1) try calling `_set`
 	if (const LuaScriptMethod *_set = p_instance->script->get_metadata().methods.getptr("_set")) {
-		Variant value_was_set = LuaFunction::invokev_lua(_set->method, Array::make(p_instance->owner, *p_name, *p_value), false);
+		Variant value_was_set = LuaFunction::invoke_lua(_set->method, Array::make(p_instance->owner, *p_name, *p_value), false);
 		if (value_was_set) {
 			return true;
 		}
@@ -79,7 +80,7 @@ GDExtensionBool set_func(LuaScriptInstance *p_instance, const StringName *p_name
 GDExtensionBool get_func(LuaScriptInstance *p_instance, const StringName *p_name, Variant *p_value) {
 	// a) try calling `_get`
 	if (const LuaScriptMethod *_get = p_instance->script->get_metadata().methods.getptr("_get")) {
-		Variant value = LuaFunction::invokev_lua(_get->method, Array::make(p_instance->owner, *p_name), false);
+		Variant value = LuaFunction::invoke_lua(_get->method, Array::make(p_instance->owner, *p_name), false);
 		if (value != Variant()) {
 			*p_value = value;
 			return true;
@@ -121,7 +122,7 @@ GDExtensionScriptInstanceGetClassCategory get_class_category_func;
 
 GDExtensionBool property_can_revert_func(LuaScriptInstance *p_instance, const StringName *p_name) {
 	if (const LuaScriptMethod *method = p_instance->script->get_metadata().methods.getptr("_property_can_revert")) {
-		Variant result = LuaFunction::invokev_lua(method->method, Array::make(p_instance->owner, *p_name), false);
+		Variant result = LuaFunction::invoke_lua(method->method, Array::make(p_instance->owner, *p_name), false);
 		if (result) {
 			return true;
 		}
@@ -132,7 +133,7 @@ GDExtensionBool property_can_revert_func(LuaScriptInstance *p_instance, const St
 
 GDExtensionBool property_get_revert_func(LuaScriptInstance *p_instance, const StringName *p_name, Variant *r_ret) {
 	if (const LuaScriptMethod *method = p_instance->script->get_metadata().methods.getptr("_property_get_revert")) {
-		Variant result = LuaFunction::invokev_lua(method->method, Array::make(p_instance->owner, *p_name), true);
+		Variant result = LuaFunction::invoke_lua(method->method, Array::make(p_instance->owner, *p_name), true);
 		if (LuaError *error = Object::cast_to<LuaError>(result)) {
 			ERR_PRINT(error->get_message());
 		}
@@ -175,7 +176,7 @@ GDExtensionBool validate_property_func(LuaScriptInstance *p_instance, GDExtensio
 	if (const LuaScriptMethod *_validate_property = p_instance->script->get_metadata().methods.getptr("_validate_property")) {
 		PropertyInfo property_info(p_property);
 		Dictionary property_info_dict = property_info;
-		LuaFunction::invokev_lua(_validate_property->method, Array::make(p_instance->owner, property_info_dict), false);
+		LuaFunction::invoke_lua(_validate_property->method, Array::make(p_instance->owner, property_info_dict), false);
 		return true;
 	}
 	else {
@@ -196,7 +197,7 @@ GDExtensionInt get_method_argument_count_func(LuaScriptInstance *p_instance, con
 void call_func(LuaScriptInstance *p_instance, const StringName *p_method, const Variant **p_args, GDExtensionInt p_argument_count, Variant *r_return, GDExtensionCallError *r_error) {
 	if (const LuaScriptMethod *method = p_instance->script->get_metadata().methods.getptr(*p_method)) {
 		r_error->error = GDEXTENSION_CALL_OK;
-		*r_return = LuaFunction::invoke_method_lua(method->method, p_instance->owner, p_args, p_argument_count, false);
+		*r_return = LuaFunction::invoke_lua(method->method, VariantArguments(p_instance->owner, p_args, p_argument_count), false);
 	}
 	else {
 		r_error->error = GDEXTENSION_CALL_ERROR_INVALID_METHOD;
@@ -205,13 +206,13 @@ void call_func(LuaScriptInstance *p_instance, const StringName *p_method, const 
 
 void notification_func(LuaScriptInstance *p_instance, int32_t p_what, GDExtensionBool p_reversed) {
 	if (const LuaScriptMethod *_notification = p_instance->script->get_metadata().methods.getptr("_notification")) {
-		LuaFunction::invokev_lua(_notification->method, Array::make(p_instance->owner, p_what, p_reversed), false);
+		LuaFunction::invoke_lua(_notification->method, Array::make(p_instance->owner, p_what, p_reversed), false);
 	}
 }
 
 void to_string_func(LuaScriptInstance *p_instance, GDExtensionBool *r_is_valid, String *r_out) {
 	if (const LuaScriptMethod *_to_string = p_instance->script->get_metadata().methods.getptr("_to_string")) {
-		Variant result = LuaFunction::invokev_lua(_to_string->method, Array::make(p_instance->owner), false);
+		Variant result = LuaFunction::invoke_lua(_to_string->method, Array::make(p_instance->owner), false);
 		if (result) {
 			*r_out = result;
 			*r_is_valid = true;

--- a/src/script-language/LuaScriptInstance.cpp
+++ b/src/script-language/LuaScriptInstance.cpp
@@ -27,6 +27,7 @@
 #include "LuaScriptLanguage.hpp"
 #include "LuaScriptMetadata.hpp"
 #include "LuaScriptProperty.hpp"
+#include "../LuaCoroutine.hpp"
 #include "../LuaError.hpp"
 #include "../LuaFunction.hpp"
 #include "../LuaTable.hpp"
@@ -55,7 +56,7 @@ LuaScriptInstance::~LuaScriptInstance() {
 GDExtensionBool set_func(LuaScriptInstance *p_instance, const StringName *p_name, const Variant *p_value) {
 	// 1) try calling `_set`
 	if (const LuaScriptMethod *_set = p_instance->script->get_metadata().methods.getptr("_set")) {
-		Variant value_was_set = LuaFunction::invoke_lua(_set->method, Array::make(p_instance->owner, *p_name, *p_value), false);
+		Variant value_was_set = LuaCoroutine::invoke_lua(_set->method, Array::make(p_instance->owner, *p_name, *p_value), false);
 		if (value_was_set) {
 			return true;
 		}
@@ -197,7 +198,7 @@ GDExtensionInt get_method_argument_count_func(LuaScriptInstance *p_instance, con
 void call_func(LuaScriptInstance *p_instance, const StringName *p_method, const Variant **p_args, GDExtensionInt p_argument_count, Variant *r_return, GDExtensionCallError *r_error) {
 	if (const LuaScriptMethod *method = p_instance->script->get_metadata().methods.getptr(*p_method)) {
 		r_error->error = GDEXTENSION_CALL_OK;
-		*r_return = LuaFunction::invoke_lua(method->method, VariantArguments(p_instance->owner, p_args, p_argument_count), false);
+		*r_return = LuaCoroutine::invoke_lua(method->method, VariantArguments(p_instance->owner, p_args, p_argument_count), false);
 	}
 	else {
 		r_error->error = GDEXTENSION_CALL_ERROR_INVALID_METHOD;
@@ -206,7 +207,7 @@ void call_func(LuaScriptInstance *p_instance, const StringName *p_method, const 
 
 void notification_func(LuaScriptInstance *p_instance, int32_t p_what, GDExtensionBool p_reversed) {
 	if (const LuaScriptMethod *_notification = p_instance->script->get_metadata().methods.getptr("_notification")) {
-		LuaFunction::invoke_lua(_notification->method, Array::make(p_instance->owner, p_what, p_reversed), false);
+		LuaCoroutine::invoke_lua(_notification->method, Array::make(p_instance->owner, p_what, p_reversed), false);
 	}
 }
 

--- a/src/script-language/LuaScriptProperty.cpp
+++ b/src/script-language/LuaScriptProperty.cpp
@@ -23,6 +23,7 @@
 #include "LuaScriptProperty.hpp"
 #include "LuaScriptInstance.hpp"
 
+#include "../LuaCoroutine.hpp"
 #include "../LuaFunction.hpp"
 #include "../utils/VariantArguments.hpp"
 #include "../utils/VariantType.hpp"
@@ -131,7 +132,7 @@ Variant LuaScriptProperty::instantiate_default_value() const {
 
 bool LuaScriptProperty::set_value(LuaScriptInstance *self, const Variant& value) const {
 	if (setter) {
-		LuaFunction::invoke_lua(*setter, Array::make(self->owner, value), false);
+		LuaCoroutine::invoke_lua(*setter, Array::make(self->owner, value), false);
 		return true;
 	}
 	else if (!setter_name.is_empty()) {

--- a/src/script-language/LuaScriptProperty.cpp
+++ b/src/script-language/LuaScriptProperty.cpp
@@ -24,6 +24,7 @@
 #include "LuaScriptInstance.hpp"
 
 #include "../LuaFunction.hpp"
+#include "../utils/VariantArguments.hpp"
 #include "../utils/VariantType.hpp"
 #include "../utils/convert_godot_lua.hpp"
 
@@ -107,7 +108,7 @@ LuaScriptProperty::LuaScriptProperty(const Variant& value, const StringName& nam
 
 bool LuaScriptProperty::get_value(LuaScriptInstance *self, Variant& r_value) const {
 	if (getter) {
-		r_value = LuaFunction::invoke_method_lua(*getter, self->owner, nullptr, 0, false);
+		r_value = LuaFunction::invoke_lua(*getter, VariantArguments(self->owner, nullptr, 0), false);
 		return true;
 	}
 	if (!getter_name.is_empty()) {
@@ -130,7 +131,7 @@ Variant LuaScriptProperty::instantiate_default_value() const {
 
 bool LuaScriptProperty::set_value(LuaScriptInstance *self, const Variant& value) const {
 	if (setter) {
-		LuaFunction::invokev_lua(*setter, Array::make(self->owner, value), false);
+		LuaFunction::invoke_lua(*setter, Array::make(self->owner, value), false);
 		return true;
 	}
 	else if (!setter_name.is_empty()) {

--- a/src/utils/LuaCoroutinePool.cpp
+++ b/src/utils/LuaCoroutinePool.cpp
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2025 Gil Barbosa Reis.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "LuaCoroutinePool.hpp"
+
+#include "stack_top_checker.hpp"
+
+namespace luagdextension {
+
+const char COROUTINE_POOL_KEY[] = "_COROUTINE_POOL";
+
+LuaCoroutinePool::LuaCoroutinePool(lua_State *L)
+	: L(L)
+{
+}
+
+sol::thread LuaCoroutinePool::acquire(const sol::function& f) {
+	StackTopChecker topcheck(L);
+	luaL_getsubtable(L, LUA_REGISTRYINDEX, COROUTINE_POOL_KEY);
+	int pool_index = lua_absindex(L, -1);
+	if (lua_Integer len = luaL_len(L, pool_index); len > 0) {
+		lua_geti(L, pool_index, len);
+		lua_settop(lua_tothread(L, -1), 0);  // reset thread
+		lua_pushnil(L);
+		lua_seti(L, pool_index, len);
+	}
+	else {
+		lua_newthread(L);
+	}
+
+	sol::thread coroutine(L, -1);
+	f.push(coroutine.thread_state());
+
+	lua_pop(L, 2);
+	return coroutine;
+}
+
+void LuaCoroutinePool::release(const sol::thread& coroutine) {
+	StackTopChecker topcheck(L);
+	if (coroutine.status() == sol::thread_status::dead) {
+		luaL_getsubtable(L, LUA_REGISTRYINDEX, COROUTINE_POOL_KEY);
+		sol::stack_table pool(L, -1);
+		pool[pool.size() + 1] = coroutine;
+		pool.pop();
+	}
+}
+
+}

--- a/src/utils/LuaCoroutinePool.hpp
+++ b/src/utils/LuaCoroutinePool.hpp
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2025 Gil Barbosa Reis.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef __UTILS_COROUTINE_POOL_HPP__
+#define __UTILS_COROUTINE_POOL_HPP__
+
+#include "sol/sol.hpp"
+
+namespace luagdextension {
+
+struct LuaCoroutinePool {
+	LuaCoroutinePool(lua_State *L);
+
+	sol::thread acquire(const sol::function& f);
+	void release(const sol::thread& coroutine);
+
+private:
+	sol::state_view L;
+};
+
+}
+
+#endif  // __UTILS_COROUTINE_POOL_HPP__

--- a/src/utils/convert_godot_lua.cpp
+++ b/src/utils/convert_godot_lua.cpp
@@ -105,9 +105,15 @@ Variant to_variant(const sol::stack_proxy_base& proxy) {
 	return to_variant<>(sol::stack_object(proxy.lua_state(), proxy.stack_index()));
 }
 
-Variant to_variant(const sol::protected_function_result& function_result) {
+Variant to_variant(const sol::protected_function_result& function_result, bool return_lua_error) {
 	if (!function_result.valid()) {
-		return memnew(LuaError(function_result));
+		if (return_lua_error) {
+			return memnew(LuaError(function_result));
+		}
+		else {
+			ERR_PRINT(LuaError::extract_message(function_result));
+			return Variant();
+		}
 	}
 
 	switch (function_result.return_count()) {
@@ -118,7 +124,7 @@ Variant to_variant(const sol::protected_function_result& function_result) {
 			return to_variant(function_result[0].get<sol::stack_object>());
 
 		default:
-			auto arr = Array();
+			Array arr;
 			for (auto value : function_result) {
 				arr.append(to_variant(value.get<sol::stack_object>()));
 			}

--- a/src/utils/convert_godot_lua.cpp
+++ b/src/utils/convert_godot_lua.cpp
@@ -175,8 +175,7 @@ sol::stack_object lua_push(lua_State *lua_state, const Variant& value) {
 			goto push_as_variant;
 			
 		case Variant::CALLABLE:
-			if (LuaState *gdlua = LuaState::find_lua_state(lua_state); gdlua->are_libraries_opened(LuaState::GODOT_VARIANT))
-			{
+			if (LuaState *gdlua = LuaState::find_lua_state(lua_state); gdlua->are_libraries_opened(LuaState::GODOT_VARIANT)) {
 				goto push_as_variant;
 			}
 			else {

--- a/src/utils/convert_godot_lua.hpp
+++ b/src/utils/convert_godot_lua.hpp
@@ -35,7 +35,7 @@ class LuaTable;
 Variant to_variant(const sol::object& object);
 Variant to_variant(const sol::stack_object& object);
 Variant to_variant(const sol::stack_proxy_base& object);
-Variant to_variant(const sol::protected_function_result& function_result);
+Variant to_variant(const sol::protected_function_result& function_result, bool return_lua_error);
 Variant to_variant(const sol::load_result& load_result);
 Variant to_variant(lua_State *L, int index);
 sol::stack_object lua_push(lua_State *L, const Variant& value);

--- a/test/gdscript_tests/await_gdscript.gd
+++ b/test/gdscript_tests/await_gdscript.gd
@@ -1,0 +1,48 @@
+extends RefCounted
+
+
+signal some_signal(value)
+
+
+func test_await_gdscript_signal() -> bool:
+	var lua = LuaState.new()
+	lua.open_libraries()
+	
+	lua.globals.some_signal = some_signal
+	var coroutine = lua.do_string("""
+		return coroutine.create(function()
+			await(some_signal)
+		end)
+	""")
+	assert(coroutine.status == LuaCoroutine.STATUS_YIELD)
+	coroutine.resume()
+	assert(coroutine.status == LuaCoroutine.STATUS_YIELD)
+
+	some_signal.emit()
+	assert(coroutine.status == LuaCoroutine.STATUS_DEAD)
+
+	return true
+
+
+func test_await_gdscript_coroutine() -> bool:
+	var lua = LuaState.new()
+	lua.open_libraries()
+	
+	lua.globals._gdscript_coroutine = _gdscript_coroutine
+	var coroutine = lua.do_string("""
+		return coroutine.create(function()
+			await(_gdscript_coroutine())
+		end)
+	""")
+	assert(coroutine.status == LuaCoroutine.STATUS_YIELD)
+	coroutine.resume()
+	assert(coroutine.status == LuaCoroutine.STATUS_YIELD)
+
+	some_signal.emit()
+	assert(coroutine.status == LuaCoroutine.STATUS_DEAD)
+
+	return true
+
+
+func _gdscript_coroutine():
+	await some_signal

--- a/test/gdscript_tests/await_gdscript.gd.uid
+++ b/test/gdscript_tests/await_gdscript.gd.uid
@@ -1,0 +1,1 @@
+uid://dmccuhtpvcsv6

--- a/test/gdscript_tests/lua_files/test_class.lua
+++ b/test/gdscript_tests/lua_files/test_class.lua
@@ -4,6 +4,7 @@ TestClass.some_signal = signal("arg1", "arg2")
 
 TestClass.empty_array = property { type = Array }
 TestClass.preinitialized_array = Array { 1, 2, 3 }
+TestClass.signal_awaited = false
 
 -- Getter methods
 TestClass.getter_counter = property {
@@ -54,6 +55,11 @@ end
 
 function TestClass:echo(value)
 	return value
+end
+
+function TestClass:await_signal(sig)
+	await(sig)
+	self.signal_awaited = true
 end
 
 return TestClass

--- a/test/gdscript_tests/test_class.gd
+++ b/test/gdscript_tests/test_class.gd
@@ -1,5 +1,7 @@
 extends RefCounted
 
+signal some_signal()
+
 var test_class = load("res://gdscript_tests/lua_files/test_class.lua")
 var _signal_handled = false
 
@@ -104,4 +106,13 @@ func test_method() -> bool:
 	assert(is_same(obj.echo(arr), arr))
 	assert(obj.echo is Callable)
 	assert(obj.echo.bind("callable").call() == "callable")
+	return true
+
+
+func test_await_signal() -> bool:
+	var obj = test_class.new()
+	obj.await_signal(some_signal)
+	assert(not obj.signal_awaited)
+	some_signal.emit()
+	assert(obj.signal_awaited)
 	return true

--- a/test/gdscript_tests/test_class.gd
+++ b/test/gdscript_tests/test_class.gd
@@ -4,6 +4,10 @@ var test_class = load("res://gdscript_tests/lua_files/test_class.lua")
 var _signal_handled = false
 
 
+func _setup():
+	_signal_handled = false
+
+
 func _handle_signal(arg1, arg2):
 	_signal_handled = true
 

--- a/test/lua_tests/await.lua
+++ b/test/lua_tests/await.lua
@@ -1,0 +1,11 @@
+local resource = Resource:new()
+
+local co = coroutine.create(function()
+	await(resource.changed)
+end)
+
+coroutine.resume(co)
+assert(coroutine.status(co) == "suspended", "await should yield coroutine")
+
+resource:emit_changed()
+assert(coroutine.status(co) == "dead", "emitting awaited signal should automatically resume coroutine")

--- a/test/lua_tests/await.lua
+++ b/test/lua_tests/await.lua
@@ -1,3 +1,5 @@
+if Engine:is_editor_hint() then return end
+
 local resource = Resource:new()
 
 local co = coroutine.create(function()

--- a/test/lua_tests/await.lua.uid
+++ b/test/lua_tests/await.lua.uid
@@ -1,0 +1,1 @@
+uid://v5lmwpruguai

--- a/test/test_entrypoint.gd
+++ b/test/test_entrypoint.gd
@@ -29,6 +29,10 @@ func _initialize():
 		for method in obj.get_method_list():
 			var method_name = method.name
 			if method_name.begins_with("test"):
+				# optional per-test setup
+				if obj.has_method("_setup"):
+					obj._setup()
+				# actual test
 				if not obj.call(method_name):
 					all_success = false
 					printerr("  🗴 ", method_name)


### PR DESCRIPTION
This PR:
- Adds `LuaCoroutine.completed` and `LuaCoroutine.failed` signals
- `await` function that can be used to yield a coroutine and resume it automatically when a signal is emitted
- Changes most of the LuaScript's method calls to run in coroutines, so that `await` is usable there by default. Such coroutines that do not yield are pooled to avoid allocations.