### PR TITLE
Add LuaCodeEdit and LuaSyntaxHighlight

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include "LuaState.hpp"
 #include "LuaTable.hpp"
 #include "LuaUserdata.hpp"
+#include "script-language/LuaCodeEdit.hpp"
 #include "script-language/LuaScript.hpp"
 #include "script-language/LuaScriptLanguage.hpp"
 #include "script-language/LuaScriptResourceFormatLoader.hpp"
@@ -68,6 +69,7 @@ static void initialize(ModuleInitializationLevel level) {
 	LuaScriptResourceFormatSaver::register_in_godot();
 
 	// Lua code editing
+	ClassDB::register_class<LuaCodeEdit>();
 	ClassDB::register_class<LuaSyntaxHighlighter>();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 #include "script-language/LuaScriptLanguage.hpp"
 #include "script-language/LuaScriptResourceFormatLoader.hpp"
 #include "script-language/LuaScriptResourceFormatSaver.hpp"
+#include "script-language/LuaSyntaxHighlighter.hpp"
 
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/core/class_db.hpp>
@@ -65,6 +66,9 @@ static void initialize(ModuleInitializationLevel level) {
 	LuaScriptLanguage::get_or_create_singleton();
 	LuaScriptResourceFormatLoader::register_in_godot();
 	LuaScriptResourceFormatSaver::register_in_godot();
+
+	// Lua code editing
+	ClassDB::register_class<LuaSyntaxHighlighter>();
 }
 
 static void deinitialize(ModuleInitializationLevel level) {

--- a/src/script-language/LuaCodeEdit.cpp
+++ b/src/script-language/LuaCodeEdit.cpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2025 Gil Barbosa Reis.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "LuaCodeEdit.hpp"
+#include "LuaScriptLanguage.hpp"
+
+namespace luagdextension {
+
+bool LuaCodeEdit::_property_can_revert(const StringName &p_name) const {
+	return Array::make("delimiter_comments", "delimiter_strings").has(p_name);
+}
+
+bool LuaCodeEdit::_property_get_revert(const StringName &p_name, Variant &r_property) const {
+	if (p_name == String("delimiter_comments")) {
+		r_property = LuaScriptLanguage::get_singleton()->_get_comment_delimiters();
+		return true;
+	}
+	else if (p_name == String("delimiter_strings")) {
+		r_property = LuaScriptLanguage::get_singleton()->_get_string_delimiters();
+		return true;
+	}
+	else {
+		return false;
+	}
+}
+
+void LuaCodeEdit::_bind_methods() {}
+
+}

--- a/src/script-language/LuaCodeEdit.hpp
+++ b/src/script-language/LuaCodeEdit.hpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2025 Gil Barbosa Reis.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef __LUA_SCRIPT_CODE_EDIT_HPP__
+#define __LUA_SCRIPT_CODE_EDIT_HPP__
+
+#include <godot_cpp/classes/code_edit.hpp>
+
+using namespace godot;
+
+namespace luagdextension {
+
+class LuaCodeEdit : public CodeEdit {
+	GDCLASS(LuaCodeEdit, CodeEdit)
+
+public:
+
+protected:
+	bool _property_can_revert(const StringName &p_name) const;
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+	static void _bind_methods();
+};
+
+}
+
+#endif

--- a/src/script-language/LuaScriptLanguage.cpp
+++ b/src/script-language/LuaScriptLanguage.cpp
@@ -97,18 +97,10 @@ void LuaScriptLanguage::_finish() {
 }
 
 PackedStringArray LuaScriptLanguage::_get_reserved_words() const {
-	return godot::helpers::append_all(PackedStringArray(),
-		// Lua keywords
-		"and", "break", "do", "else", "elseif", "end",
-		"false", "for", "function", "goto", "if", "in",
-		"local", "nil", "not", "or", "repeat", "return",
-		"then", "true", "until", "while",
-		// Other remarkable identifiers
-#if LUA_VERSION_NUM >= 502
-		"_ENV",
-#endif
-		"self", "_G", "_VERSION"
-	);
+	PackedStringArray reserved_words;
+	reserved_words.append_array(get_lua_keywords());
+	reserved_words.append_array(get_lua_member_keywords());
+	return reserved_words;
 }
 
 bool LuaScriptLanguage::_is_control_flow_keyword(const String &keyword) const {
@@ -409,6 +401,26 @@ Dictionary LuaScriptLanguage::_get_global_class_name(const String &path) const {
 		result["is_tool"] = script->_is_tool();
 	}
 	return result;
+}
+
+PackedStringArray LuaScriptLanguage::get_lua_keywords() const {
+	return godot::helpers::append_all(PackedStringArray(),
+		// Lua keywords
+		"and", "break", "do", "else", "elseif", "end",
+		"false", "for", "function", "goto", "if", "in",
+		"local", "nil", "not", "or", "repeat", "return",
+		"then", "true", "until", "while"
+	);
+}
+
+PackedStringArray LuaScriptLanguage::get_lua_member_keywords() const {
+	return godot::helpers::append_all(PackedStringArray(),
+		// Remarkable identifiers
+#if LUA_VERSION_NUM >= 502
+		"_ENV",
+#endif
+		"self", "_G", "_VERSION"
+	);
 }
 
 LuaState *LuaScriptLanguage::get_lua_state() {

--- a/src/script-language/LuaScriptLanguage.hpp
+++ b/src/script-language/LuaScriptLanguage.hpp
@@ -95,6 +95,9 @@ public:
 	bool _handles_global_class_type(const String &p_type) const override;
 	Dictionary _get_global_class_name(const String &p_path) const override;
 
+	PackedStringArray get_lua_keywords() const;
+	PackedStringArray get_lua_member_keywords() const;
+
 	LuaState *get_lua_state();
 
 	static LuaScriptLanguage *get_singleton();

--- a/src/script-language/LuaScriptLanguage.hpp
+++ b/src/script-language/LuaScriptLanguage.hpp
@@ -22,13 +22,14 @@
 #ifndef __LUA_SCRIPT_LANGUAGE_EXTENSION_HPP__
 #define __LUA_SCRIPT_LANGUAGE_EXTENSION_HPP__
 
+#include <godot_cpp/classes/script.hpp>
 #include <godot_cpp/classes/script_language_extension.hpp>
+
+#include "../LuaState.hpp"
 
 using namespace godot;
 
 namespace luagdextension {
-
-class LuaState;
 
 class LuaScriptLanguage : public ScriptLanguageExtension {
 	GDCLASS(LuaScriptLanguage, ScriptLanguageExtension);

--- a/src/script-language/LuaSyntaxHighlighter.cpp
+++ b/src/script-language/LuaSyntaxHighlighter.cpp
@@ -31,10 +31,24 @@ Color LuaSyntaxHighlighter::get_lua_keyword_color() const {
 void LuaSyntaxHighlighter::set_lua_keyword_color(Color color) {
 	lua_keyword_color = color;
 	Dictionary keyword_colors = get_keyword_colors();
-	for (String& keyword : LuaScriptLanguage::get_singleton()->_get_reserved_words()) {
+	for (String& keyword : LuaScriptLanguage::get_singleton()->get_lua_keywords()) {
 		keyword_colors[keyword] = color;
 	}
 	set_keyword_colors(keyword_colors);
+	emit_changed();
+}
+
+Color LuaSyntaxHighlighter::get_lua_member_keyword_color() const {
+	return lua_member_keyword_color;
+}
+
+void LuaSyntaxHighlighter::set_lua_member_keyword_color(Color color) {
+	lua_member_keyword_color = color;
+	Dictionary member_keyword_colors = get_member_keyword_colors();
+	for (String& keyword : LuaScriptLanguage::get_singleton()->get_lua_member_keywords()) {
+		member_keyword_colors[keyword] = color;
+	}
+	set_member_keyword_colors(member_keyword_colors);
 	emit_changed();
 }
 
@@ -69,12 +83,15 @@ void LuaSyntaxHighlighter::set_comment_color(Color color) {
 void LuaSyntaxHighlighter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_lua_keyword_color"), &LuaSyntaxHighlighter::get_lua_keyword_color);
 	ClassDB::bind_method(D_METHOD("set_lua_keyword_color", "color"), &LuaSyntaxHighlighter::set_lua_keyword_color);
+	ClassDB::bind_method(D_METHOD("get_lua_member_keyword_color"), &LuaSyntaxHighlighter::get_lua_member_keyword_color);
+	ClassDB::bind_method(D_METHOD("set_lua_member_keyword_color", "color"), &LuaSyntaxHighlighter::set_lua_member_keyword_color);
 	ClassDB::bind_method(D_METHOD("get_string_color"), &LuaSyntaxHighlighter::get_string_color);
 	ClassDB::bind_method(D_METHOD("set_string_color", "color"), &LuaSyntaxHighlighter::set_string_color);
 	ClassDB::bind_method(D_METHOD("get_comment_color"), &LuaSyntaxHighlighter::get_comment_color);
 	ClassDB::bind_method(D_METHOD("set_comment_color", "color"), &LuaSyntaxHighlighter::set_comment_color);
 
 	ADD_PROPERTY(PropertyInfo(Variant::Type::COLOR, "lua_keyword_color"), "set_lua_keyword_color", "get_lua_keyword_color");
+	ADD_PROPERTY(PropertyInfo(Variant::Type::COLOR, "lua_member_keyword_color"), "set_lua_member_keyword_color", "get_lua_member_keyword_color");
 	ADD_PROPERTY(PropertyInfo(Variant::Type::COLOR, "string_color"), "set_string_color", "get_string_color");
 	ADD_PROPERTY(PropertyInfo(Variant::Type::COLOR, "comment_color"), "set_comment_color", "get_comment_color");
 }

--- a/src/script-language/LuaSyntaxHighlighter.cpp
+++ b/src/script-language/LuaSyntaxHighlighter.cpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2025 Gil Barbosa Reis.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "LuaSyntaxHighlighter.hpp"
+#include "LuaScriptLanguage.hpp"
+
+namespace luagdextension {
+
+Color LuaSyntaxHighlighter::get_lua_keyword_color() const {
+	return lua_keyword_color;
+}
+
+void LuaSyntaxHighlighter::set_lua_keyword_color(Color color) {
+	lua_keyword_color = color;
+	Dictionary keyword_colors = get_keyword_colors();
+	for (String& keyword : LuaScriptLanguage::get_singleton()->_get_reserved_words()) {
+		keyword_colors[keyword] = color;
+	}
+	set_keyword_colors(keyword_colors);
+	emit_changed();
+}
+
+Color LuaSyntaxHighlighter::get_string_color() const {
+	return string_color;
+}
+
+void LuaSyntaxHighlighter::set_string_color(Color color) {
+	string_color = color;
+	Dictionary color_regions = get_color_regions();
+	for (String& string_delimiter : LuaScriptLanguage::get_singleton()->_get_string_delimiters()) {
+		color_regions[string_delimiter] = color;
+	}
+	set_color_regions(color_regions);
+	emit_changed();
+}
+
+Color LuaSyntaxHighlighter::get_comment_color() const {
+	return comment_color;
+}
+
+void LuaSyntaxHighlighter::set_comment_color(Color color) {
+	comment_color = color;
+	Dictionary color_regions = get_color_regions();
+	for (String& comment_delimiter : LuaScriptLanguage::get_singleton()->_get_comment_delimiters()) {
+		color_regions[comment_delimiter] = color;
+	}
+	set_color_regions(color_regions);
+	emit_changed();
+}
+
+void LuaSyntaxHighlighter::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_lua_keyword_color"), &LuaSyntaxHighlighter::get_lua_keyword_color);
+	ClassDB::bind_method(D_METHOD("set_lua_keyword_color", "color"), &LuaSyntaxHighlighter::set_lua_keyword_color);
+	ClassDB::bind_method(D_METHOD("get_string_color"), &LuaSyntaxHighlighter::get_string_color);
+	ClassDB::bind_method(D_METHOD("set_string_color", "color"), &LuaSyntaxHighlighter::set_string_color);
+	ClassDB::bind_method(D_METHOD("get_comment_color"), &LuaSyntaxHighlighter::get_comment_color);
+	ClassDB::bind_method(D_METHOD("set_comment_color", "color"), &LuaSyntaxHighlighter::set_comment_color);
+
+	ADD_PROPERTY(PropertyInfo(Variant::Type::COLOR, "lua_keyword_color"), "set_lua_keyword_color", "get_lua_keyword_color");
+	ADD_PROPERTY(PropertyInfo(Variant::Type::COLOR, "string_color"), "set_string_color", "get_string_color");
+	ADD_PROPERTY(PropertyInfo(Variant::Type::COLOR, "comment_color"), "set_comment_color", "get_comment_color");
+}
+
+}

--- a/src/script-language/LuaSyntaxHighlighter.cpp
+++ b/src/script-language/LuaSyntaxHighlighter.cpp
@@ -22,6 +22,9 @@
 #include "LuaSyntaxHighlighter.hpp"
 #include "LuaScriptLanguage.hpp"
 
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/editor_settings.hpp>
+
 namespace luagdextension {
 
 Color LuaSyntaxHighlighter::get_lua_keyword_color() const {
@@ -80,7 +83,31 @@ void LuaSyntaxHighlighter::set_comment_color(Color color) {
 	emit_changed();
 }
 
+#ifdef DEBUG_ENABLED
+void LuaSyntaxHighlighter::fill_editor_colors() {
+	Ref<EditorSettings> editor_settings = EditorInterface::get_singleton()->get_editor_settings();
+	set_lua_keyword_color(editor_settings->get_setting("text_editor/theme/highlighting/keyword_color"));
+	set_lua_member_keyword_color(editor_settings->get_setting("text_editor/theme/highlighting/control_flow_keyword_color"));
+	set_string_color(editor_settings->get_setting("text_editor/theme/highlighting/string_color"));
+	set_comment_color(editor_settings->get_setting("text_editor/theme/highlighting/comment_color"));
+	set_number_color(editor_settings->get_setting("text_editor/theme/highlighting/number_color"));
+	set_symbol_color(editor_settings->get_setting("text_editor/theme/highlighting/symbol_color"));
+	set_function_color(editor_settings->get_setting("text_editor/theme/highlighting/gdscript/function_definition_color"));
+	set_member_variable_color(editor_settings->get_setting("text_editor/theme/highlighting/member_variable_color"));
+}
+
+Callable LuaSyntaxHighlighter::get_fill_editor_colors() const {
+	return Callable((Object *) this, "fill_editor_colors");
+}
+#endif
+
 void LuaSyntaxHighlighter::_bind_methods() {
+#ifdef DEBUG_ENABLED
+	ClassDB::bind_method(D_METHOD("fill_editor_colors"), &LuaSyntaxHighlighter::fill_editor_colors);
+	ClassDB::bind_method(D_METHOD("get_fill_editor_colors"), &LuaSyntaxHighlighter::get_fill_editor_colors);
+	ADD_PROPERTY(PropertyInfo(Variant::Type::CALLABLE, "fill_editor_colors", godot::PROPERTY_HINT_TOOL_BUTTON, "Fill with Editor colors"), "", "get_fill_editor_colors");
+#endif
+
 	ClassDB::bind_method(D_METHOD("get_lua_keyword_color"), &LuaSyntaxHighlighter::get_lua_keyword_color);
 	ClassDB::bind_method(D_METHOD("set_lua_keyword_color", "color"), &LuaSyntaxHighlighter::set_lua_keyword_color);
 	ClassDB::bind_method(D_METHOD("get_lua_member_keyword_color"), &LuaSyntaxHighlighter::get_lua_member_keyword_color);

--- a/src/script-language/LuaSyntaxHighlighter.hpp
+++ b/src/script-language/LuaSyntaxHighlighter.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2025 Gil Barbosa Reis.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the “Software”), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef __LUA_SCRIPT_SYNTAX_HIGHLIGHTER_HPP__
+#define __LUA_SCRIPT_SYNTAX_HIGHLIGHTER_HPP__
+
+#include <godot_cpp/classes/code_highlighter.hpp>
+
+using namespace godot;
+
+namespace luagdextension {
+
+class LuaSyntaxHighlighter : public CodeHighlighter {
+	GDCLASS(LuaSyntaxHighlighter, CodeHighlighter)
+
+public:
+	Color get_lua_keyword_color() const;
+	void set_lua_keyword_color(Color color);
+
+	Color get_string_color() const;
+	void set_string_color(Color color);
+	
+	Color get_comment_color() const;
+	void set_comment_color(Color color);
+
+protected:
+	static void _bind_methods();
+
+	Color lua_keyword_color;
+	Color string_color;
+	Color comment_color;
+};
+
+}
+
+#endif

--- a/src/script-language/LuaSyntaxHighlighter.hpp
+++ b/src/script-language/LuaSyntaxHighlighter.hpp
@@ -34,6 +34,9 @@ class LuaSyntaxHighlighter : public CodeHighlighter {
 public:
 	Color get_lua_keyword_color() const;
 	void set_lua_keyword_color(Color color);
+	
+	Color get_lua_member_keyword_color() const;
+	void set_lua_member_keyword_color(Color color);
 
 	Color get_string_color() const;
 	void set_string_color(Color color);
@@ -45,6 +48,7 @@ protected:
 	static void _bind_methods();
 
 	Color lua_keyword_color;
+	Color lua_member_keyword_color;
 	Color string_color;
 	Color comment_color;
 };

--- a/src/script-language/LuaSyntaxHighlighter.hpp
+++ b/src/script-language/LuaSyntaxHighlighter.hpp
@@ -44,6 +44,11 @@ public:
 	Color get_comment_color() const;
 	void set_comment_color(Color color);
 
+#ifdef DEBUG_ENABLED
+	void fill_editor_colors();
+	Callable get_fill_editor_colors() const;
+#endif
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
Adds custom `CodeEdit` and `SyntaxHighlight` subclasses specific for Lua language. Resolves #61. 