### PR TITLE
Add script import/reload toggle

### DIFF
--- a/src/script-language/LuaScript.hpp
+++ b/src/script-language/LuaScript.hpp
@@ -91,6 +91,8 @@ protected:
 
 	void _update_placeholder_exports(void *placeholder) const;
 
+	bool _verify_importability() const;
+
 	String source_code;
 	LuaScriptMetadata metadata;
 	bool placeholder_fallback_enabled;

--- a/src/script-language/LuaScriptLanguage.cpp
+++ b/src/script-language/LuaScriptLanguage.cpp
@@ -30,6 +30,7 @@
 #include "../LuaTable.hpp"
 #include "../LuaState.hpp"
 #include "../utils/function_wrapper.hpp"
+#include "../utils/project_settings.hpp"
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
@@ -40,19 +41,6 @@
 #include <godot_cpp/variant/packed_string_array.hpp>
 
 namespace luagdextension {
-
-constexpr char LUA_PATH_SETTING[] = "lua_gdextension/lua_script_language/package_path";
-constexpr char LUA_CPATH_SETTING[] = "lua_gdextension/lua_script_language/package_c_path";
-constexpr char LUA_CPATH_WINDOWS_SETTING[] = "lua_gdextension/lua_script_language/package_c_path.windows";
-constexpr char LUA_CPATH_MACOS_SETTING[] = "lua_gdextension/lua_script_language/package_c_path.macos";
-
-static void add_project_setting(ProjectSettings *project_settings, const String& setting_name, const Variant& initial_value, bool is_basic = false) {
-	if (!project_settings->has_setting(setting_name)) {
-		project_settings->set_setting(setting_name, initial_value);
-	}
-	project_settings->set_initial_value(setting_name, initial_value);
-	project_settings->set_as_basic(setting_name, is_basic);
-}
 
 String LuaScriptLanguage::_get_name() const {
 	return "Lua";
@@ -78,6 +66,7 @@ void LuaScriptLanguage::_init() {
 	add_project_setting(project_settings, LUA_CPATH_SETTING, "!/?.so;!/loadall.so");
 	add_project_setting(project_settings, LUA_CPATH_WINDOWS_SETTING, "!/?.dll;!/loadall.dll");
 	add_project_setting(project_settings, LUA_CPATH_MACOS_SETTING, "!/?.dylib;!/loadall.dylib");
+	add_project_setting(project_settings, LUA_DOIMPORT_SETTING, true);
 
 	// Apply project settings (package.path, package.cpath)
 	lua_state->set_package_path(project_settings->get_setting_with_override(LUA_PATH_SETTING));

--- a/src/script-language/LuaScriptMetadata.cpp
+++ b/src/script-language/LuaScriptMetadata.cpp
@@ -30,7 +30,7 @@
 namespace luagdextension {
 
 void LuaScriptMetadata::setup(const sol::table& t) {
-	is_valid = true;
+	is_importable = true;
 
 	sol::state_view L = t.lua_state();
 	StackTopChecker topcheck(L);
@@ -89,6 +89,7 @@ void LuaScriptMetadata::setup(const sol::table& t) {
 }
 
 void LuaScriptMetadata::clear() {
+	is_importable = false;
 	is_valid = false;
 	is_tool = false;
 	base_class = RefCounted::get_class_static();

--- a/src/utils/project_settings.hpp
+++ b/src/utils/project_settings.hpp
@@ -19,34 +19,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef __LUA_SCRIPT_METADATA_HPP__
-#define __LUA_SCRIPT_METADATA_HPP__
+#ifndef __UTILS_PROJECT_SETTINGS_HPP__
+#define __UTILS_PROJECT_SETTINGS_HPP__
 
-#include <godot_cpp/templates/hash_map.hpp>
-
-#include "LuaScriptMethod.hpp"
-#include "LuaScriptProperty.hpp"
-#include "LuaScriptSignal.hpp"
+#include <godot_cpp/classes/project_settings.hpp>
 
 using namespace godot;
 
 namespace luagdextension {
 
-struct LuaScriptMetadata {
-	bool is_importable;
-	bool is_valid;
-	bool is_tool;
-	StringName base_class;
-	StringName class_name;
-	String icon_path;
-	HashMap<StringName, LuaScriptMethod> methods;
-	HashMap<StringName, LuaScriptProperty> properties;
-	HashMap<StringName, LuaScriptSignal> signals;
+constexpr char LUA_PATH_SETTING[] = "lua_gdextension/lua_script_language/package_path";
+constexpr char LUA_CPATH_SETTING[] = "lua_gdextension/lua_script_language/package_c_path";
+constexpr char LUA_CPATH_WINDOWS_SETTING[] = "lua_gdextension/lua_script_language/package_c_path.windows";
+constexpr char LUA_CPATH_MACOS_SETTING[] = "lua_gdextension/lua_script_language/package_c_path.macos";
+constexpr char LUA_DOIMPORT_SETTING[] = "lua_gdextension/lua_script_language/import_lua_scripts";
 
-	void setup(const sol::table& t);
-	void clear();
-};
+static void add_project_setting(ProjectSettings *project_settings, const String& setting_name, const Variant& initial_value, bool is_basic = false) {
+	if (!project_settings->has_setting(setting_name)) {
+		project_settings->set_setting(setting_name, initial_value);
+	}
+	project_settings->set_initial_value(setting_name, initial_value);
+	project_settings->set_as_basic(setting_name, is_basic);
+}
 
 }
 
-#endif  // __LUA_SCRIPT_METADATA_HPP__
+#endif  // __UTILS_PROJECT_SETTINGS_HPP__


### PR DESCRIPTION
Adds a project setting (`lua_gdextension/lua_script_language/import_lua_scripts`) to toggle the automatic importing and reloading of LuaScripts, as well as allowing the first-line comments `--!noimport` (to disable importing for a specific script, when the global toggle is `true`) and `--!doimport` (to enable importing for a specific script, when the global toggle is `false`). The default for the project setting is `true`, which should keep things behaving as they do now.

These toggles come in handy when one is editing a Lua script in the Godot editor that is not intended to be attached to a node (for example, a library), and the editor's automatic reloading and execution of the script for every change is undesired.

Additionally, this PR moves the project setting name constants and `add_project_setting` function out of `LuaScriptLanguage.cpp` and into their own file, for other classes' usage.

This should probably eventually be documented somewhere, maybe in the `README`?

Should resolve #39.