### PR TITLE
LuaThread

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,7 @@ indent_size = 4
 [Makefile]
 indent_style = tab
 indent_size = 8
+
+[doc_classes/*.xml]
+indent_style = tab
+indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Support Windows arm64 exports
 - Support for calling static methods from Godot classes, like `FileAccess.open`
 - Custom [Lua 5.4+ warning function](https://www.lua.org/manual/5.4/manual.html#lua_setwarnf) that sends messages to `push_warning`
+- `LuaThread` class as a superclass for `LuaCoroutine`.
+  This new class is used when converting a LuaState's main thread to Variant.
+- `LuaState.main_thread` property for getting a Lua state's main thread of execution
 
 ### Changed
 - `LuaObject` instances are reused when wrapping the same Lua object, so that `==` and `is_same` can be used properly

--- a/doc_classes/LuaCoroutine.xml
+++ b/doc_classes/LuaCoroutine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="LuaCoroutine" inherits="LuaObject" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="LuaCoroutine" inherits="LuaThread" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		A Lua coroutine object that allows cooperative multitasking in Lua scripts.
 	</brief_description>
@@ -59,48 +59,20 @@
 			</description>
 		</method>
 	</methods>
-	<members>
-		<member name="status" type="int" setter="" getter="get_status" enum="LuaCoroutine.Status">
-			The current status of the coroutine.
-		</member>
-	</members>
 	<signals>
 		<signal name="completed">
 			<param index="0" name="result" type="Variant" />
 			<description>
-        Emitted when the coroutine completes execution with success and is in the STATUS_DEAD status.
-        Coroutines that complete cannot be resumed anymore.
+				Emitted when the coroutine completes execution with success and is in the STATUS_DEAD status.
+				Coroutines that complete cannot be resumed anymore.
 			</description>
 		</signal>
 		<signal name="failed">
 			<param index="0" name="error" type="LuaError" />
 			<description>
-        Emitted when the coroutine completes execution with error and is in one of the error statuses.
-        Coroutines that fail cannot be resumed anymore.
+				Emitted when the coroutine completes execution with error and is in one of the error statuses.
+				Coroutines that fail cannot be resumed anymore.
 			</description>
 		</signal>
 	</signals>
-	<constants>
-		<constant name="STATUS_OK" value="0" enum="Status">
-			The coroutine is running normally.
-		</constant>
-		<constant name="STATUS_YIELD" value="1" enum="Status">
-			The coroutine is suspended (yielded).
-		</constant>
-		<constant name="STATUS_ERRRUN" value="2" enum="Status">
-			A runtime error occurred in the coroutine.
-		</constant>
-		<constant name="STATUS_ERRSYNTAX" value="3" enum="Status">
-			A syntax error occurred in the coroutine.
-		</constant>
-		<constant name="STATUS_ERRMEM" value="4" enum="Status">
-			A memory allocation error occurred in the coroutine.
-		</constant>
-		<constant name="STATUS_ERRERR" value="5" enum="Status">
-			An error occurred while running the error handler.
-		</constant>
-		<constant name="STATUS_DEAD" value="-1" enum="Status">
-			The coroutine has finished execution.
-		</constant>
-	</constants>
 </class>

--- a/doc_classes/LuaState.xml
+++ b/doc_classes/LuaState.xml
@@ -184,6 +184,9 @@
 			Returns the _G table of the LuaState.
 			The _G table is the global table accessible to Lua scripts.
 		</member>
+		<member name="main_thread" type="LuaThread" setter="" getter="get_main_thread">
+			The main thread of execution of the LuaState.
+		</member>
 		<member name="package_cpath" type="String" setter="set_package_cpath" getter="get_package_cpath">
 			The search path for Lua C extension modules. Equivalent to Lua's [code]package.cpath[/code] variable.
 			When you use the [code]require[/code] function to load a C extension module, Lua searches the paths defined in [code]package.cpath[/code].

--- a/doc_classes/LuaThread.xml
+++ b/doc_classes/LuaThread.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LuaThread" inherits="LuaObject" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		An object that represents a thread of execution in the Lua virtual machine.
+	</brief_description>
+	<description>
+		The LuaThread class represents a thread of execution in the Lua virtual machine.
+		Apart from [member LuaState.main_thread], all other threads of execution are [LuaCoroutine]s.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_main_thread" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Whether this thread is the [LuaState]'s main thread.
+				See also [member LuaState.main_thread].
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="status" type="int" setter="" getter="get_status" enum="LuaThread.Status">
+			The current status of the thread.
+		</member>
+	</members>
+	<constants>
+		<constant name="STATUS_OK" value="0" enum="Status">
+			The thread is running normally.
+		</constant>
+		<constant name="STATUS_YIELD" value="1" enum="Status">
+			The thread is suspended (yielded).
+		</constant>
+		<constant name="STATUS_ERRRUN" value="2" enum="Status">
+			A runtime error occurred in the thread.
+		</constant>
+		<constant name="STATUS_ERRSYNTAX" value="3" enum="Status">
+			A syntax error occurred in the thread.
+		</constant>
+		<constant name="STATUS_ERRMEM" value="4" enum="Status">
+			A memory allocation error occurred in the thread.
+		</constant>
+		<constant name="STATUS_ERRERR" value="5" enum="Status">
+			An error occurred while running the error handler.
+		</constant>
+		<constant name="STATUS_DEAD" value="-1" enum="Status">
+			The thread has finished execution.
+		</constant>
+	</constants>
+</class>

--- a/src/LuaCoroutine.cpp
+++ b/src/LuaCoroutine.cpp
@@ -31,9 +31,9 @@
 
 namespace luagdextension {
 
-LuaCoroutine::LuaCoroutine() : LuaObjectSubclass() {}
-LuaCoroutine::LuaCoroutine(sol::thread&& thread) : LuaObjectSubclass(thread) {}
-LuaCoroutine::LuaCoroutine(const sol::thread& thread) : LuaObjectSubclass(thread) {}
+LuaCoroutine::LuaCoroutine() : LuaThread() {}
+LuaCoroutine::LuaCoroutine(sol::thread&& thread) : LuaThread(thread) {}
+LuaCoroutine::LuaCoroutine(const sol::thread& thread) : LuaThread(thread) {}
 
 LuaCoroutine *LuaCoroutine::create(const sol::function& function) {
 	sol::thread thread = sol::thread::create(function.lua_state());
@@ -44,10 +44,6 @@ LuaCoroutine *LuaCoroutine::create(const sol::function& function) {
 LuaCoroutine *LuaCoroutine::create(LuaFunction *function) {
 	ERR_FAIL_COND_V_MSG(function == nullptr, nullptr, "Function cannot be null");
 	return create(function->get_function());
-}
-
-LuaCoroutine::Status LuaCoroutine::get_status() const {
-	return static_cast<Status>(lua_object.status());
 }
 
 Variant LuaCoroutine::resume(const Variant **args, GDExtensionInt arg_count, GDExtensionCallError& error) {
@@ -98,20 +94,9 @@ Variant LuaCoroutine::invoke_lua(const sol::protected_function& f, const Variant
 }
 
 void LuaCoroutine::_bind_methods() {
-	BIND_ENUM_CONSTANT(STATUS_OK);
-	BIND_ENUM_CONSTANT(STATUS_YIELD);
-	BIND_ENUM_CONSTANT(STATUS_ERRRUN);
-	BIND_ENUM_CONSTANT(STATUS_ERRSYNTAX);
-	BIND_ENUM_CONSTANT(STATUS_ERRMEM);
-	BIND_ENUM_CONSTANT(STATUS_ERRERR);
-	BIND_ENUM_CONSTANT(STATUS_DEAD);
-
-	ClassDB::bind_method(D_METHOD("get_status"), &LuaCoroutine::get_status);
 	ClassDB::bind_method(D_METHOD("resumev", "arguments"), &LuaCoroutine::resumev);
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "resume", &LuaCoroutine::resume);
 	ClassDB::bind_static_method(get_class_static(), D_METHOD("create", "function"), sol::resolve<LuaCoroutine *(LuaFunction *)>(&LuaCoroutine::create));
-
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "status", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CLASS_IS_ENUM, "Status"), "", "get_status");
 
 	ADD_SIGNAL(MethodInfo("completed", PropertyInfo(Variant::NIL, "result", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 	ADD_SIGNAL(MethodInfo("failed", PropertyInfo(Variant::OBJECT, "error", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, LuaError::get_class_static())));

--- a/src/LuaState.cpp
+++ b/src/LuaState.cpp
@@ -23,6 +23,7 @@
 
 #include "LuaFunction.hpp"
 #include "LuaTable.hpp"
+#include "LuaThread.hpp"
 #include "luaopen/godot.hpp"
 #include "utils/_G_metatable.hpp"
 #include "utils/convert_godot_lua.hpp"
@@ -196,6 +197,10 @@ LuaTable *LuaState::get_registry() const {
 	return LuaObject::wrap_object<LuaTable>(lua_state.registry());
 }
 
+LuaThread *LuaState::get_main_thread() const {
+	return LuaObject::wrap_object<LuaThread>(sol::thread(lua_state, lua_state));
+}
+
 String LuaState::get_package_path() const {
 	if (auto package = lua_state.get<sol::optional<sol::table>>("package")) {
 		return package->get<String>("path");
@@ -321,6 +326,7 @@ void LuaState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("do_file", "filename", "mode", "env"), &LuaState::do_file, DEFVAL(LOAD_MODE_ANY), DEFVAL(nullptr));
 	ClassDB::bind_method(D_METHOD("get_globals"), &LuaState::get_globals);
 	ClassDB::bind_method(D_METHOD("get_registry"), &LuaState::get_registry);
+	ClassDB::bind_method(D_METHOD("get_main_thread"), &LuaState::get_main_thread);
 	ClassDB::bind_method(D_METHOD("get_package_path"), &LuaState::get_package_path);
 	ClassDB::bind_method(D_METHOD("get_package_cpath"), &LuaState::get_package_cpath);
 	ClassDB::bind_method(D_METHOD("set_package_path", "path"), &LuaState::set_package_path);
@@ -330,6 +336,7 @@ void LuaState::_bind_methods() {
 	// Properties
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "globals", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, LuaTable::get_class_static()), "", "get_globals");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "registry", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, LuaTable::get_class_static()), "", "get_registry");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "main_thread", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE, LuaThread::get_class_static()), "", "get_main_thread");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "package_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_package_path", "get_package_path");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "package_cpath", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_package_cpath", "get_package_cpath");
 }

--- a/src/LuaState.hpp
+++ b/src/LuaState.hpp
@@ -33,6 +33,7 @@ namespace luagdextension {
 
 class LuaFunction;
 class LuaTable;
+class LuaThread;
 
 class LuaState : public RefCounted {
 	GDCLASS(LuaState, RefCounted);
@@ -115,6 +116,7 @@ public:
 
 	LuaTable *get_globals() const;
 	LuaTable *get_registry() const;
+	LuaThread *get_main_thread() const;
 
 	String get_package_path() const;
 	String get_package_cpath() const;

--- a/src/LuaThread.cpp
+++ b/src/LuaThread.cpp
@@ -19,43 +19,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef __LUA_COROUTINE_HPP__
-#define __LUA_COROUTINE_HPP__
-
 #include "LuaThread.hpp"
-
-#include <gdextension_interface.h>
-
-using namespace godot;
 
 namespace luagdextension {
 
-class LuaFunction;
+LuaThread::LuaThread() : LuaObjectSubclass() {}
+LuaThread::LuaThread(sol::thread&& thread) : LuaObjectSubclass(thread) {}
+LuaThread::LuaThread(const sol::thread& thread) : LuaObjectSubclass(thread) {}
 
-class LuaCoroutine : public LuaThread {
-	GDCLASS(LuaCoroutine, LuaThread);
-
-public:
-	LuaCoroutine();
-	LuaCoroutine(sol::thread&& thread);
-	LuaCoroutine(const sol::thread& thread);
-
-	static LuaCoroutine *create(const sol::function& function);
-	static LuaCoroutine *create(LuaFunction *function);
-
-	Variant resumev(const Array& args);
-	Variant resume(const Variant **argv, GDExtensionInt argc, GDExtensionCallError& error);
-
-	static Variant invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error);
-
-protected:
-	static void _bind_methods();
-	
-private:
-	Variant _resume(const VariantArguments& args, bool return_lua_error);
-	static sol::protected_function_result _resume(lua_State *L, const VariantArguments& args);
-};
-
+LuaThread::Status LuaThread::get_status() const {
+	return static_cast<Status>(lua_object.status());
 }
 
-#endif
+void LuaThread::_bind_methods() {
+	BIND_ENUM_CONSTANT(STATUS_OK);
+	BIND_ENUM_CONSTANT(STATUS_YIELD);
+	BIND_ENUM_CONSTANT(STATUS_ERRRUN);
+	BIND_ENUM_CONSTANT(STATUS_ERRSYNTAX);
+	BIND_ENUM_CONSTANT(STATUS_ERRMEM);
+	BIND_ENUM_CONSTANT(STATUS_ERRERR);
+	BIND_ENUM_CONSTANT(STATUS_DEAD);
+
+	ClassDB::bind_method(D_METHOD("get_status"), &LuaThread::get_status);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "status", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CLASS_IS_ENUM, "Status"), "", "get_status");
+}
+
+}

--- a/src/LuaThread.cpp
+++ b/src/LuaThread.cpp
@@ -31,6 +31,10 @@ LuaThread::Status LuaThread::get_status() const {
 	return static_cast<Status>(lua_object.status());
 }
 
+bool LuaThread::is_main_thread() const {
+	return lua_object.is_main_thread();
+}
+
 void LuaThread::_bind_methods() {
 	BIND_ENUM_CONSTANT(STATUS_OK);
 	BIND_ENUM_CONSTANT(STATUS_YIELD);
@@ -41,6 +45,7 @@ void LuaThread::_bind_methods() {
 	BIND_ENUM_CONSTANT(STATUS_DEAD);
 
 	ClassDB::bind_method(D_METHOD("get_status"), &LuaThread::get_status);
+	ClassDB::bind_method(D_METHOD("is_main_thread"), &LuaThread::is_main_thread);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "status", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CLASS_IS_ENUM, "Status"), "", "get_status");
 }

--- a/src/LuaThread.hpp
+++ b/src/LuaThread.hpp
@@ -19,43 +19,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef __LUA_COROUTINE_HPP__
-#define __LUA_COROUTINE_HPP__
+#ifndef __LUA_THREAD_HPP__
+#define __LUA_THREAD_HPP__
 
-#include "LuaThread.hpp"
-
-#include <gdextension_interface.h>
+#include "LuaObject.hpp"
 
 using namespace godot;
 
 namespace luagdextension {
 
-class LuaFunction;
-
-class LuaCoroutine : public LuaThread {
-	GDCLASS(LuaCoroutine, LuaThread);
+class LuaThread : public LuaObjectSubclass<sol::thread> {
+	GDCLASS(LuaThread, LuaObject);
 
 public:
-	LuaCoroutine();
-	LuaCoroutine(sol::thread&& thread);
-	LuaCoroutine(const sol::thread& thread);
+	enum Status {
+		STATUS_OK = LUA_OK,
+		STATUS_YIELD = LUA_YIELD,
+		STATUS_ERRRUN = LUA_ERRRUN,
+		STATUS_ERRSYNTAX = LUA_ERRSYNTAX,
+		STATUS_ERRMEM = LUA_ERRMEM,
+		STATUS_ERRERR = LUA_ERRERR,
+		STATUS_DEAD = (int) sol::thread_status::dead,
+	};
 
-	static LuaCoroutine *create(const sol::function& function);
-	static LuaCoroutine *create(LuaFunction *function);
+	LuaThread();
+	LuaThread(sol::thread&& thread);
+	LuaThread(const sol::thread& thread);
 
-	Variant resumev(const Array& args);
-	Variant resume(const Variant **argv, GDExtensionInt argc, GDExtensionCallError& error);
-
-	static Variant invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error);
-
+	Status get_status() const;
+	
 protected:
 	static void _bind_methods();
-	
-private:
-	Variant _resume(const VariantArguments& args, bool return_lua_error);
-	static sol::protected_function_result _resume(lua_State *L, const VariantArguments& args);
 };
 
 }
+VARIANT_ENUM_CAST(luagdextension::LuaThread::Status);
 
 #endif

--- a/src/LuaThread.hpp
+++ b/src/LuaThread.hpp
@@ -47,6 +47,7 @@ public:
 	LuaThread(const sol::thread& thread);
 
 	Status get_status() const;
+	bool is_main_thread() const;
 	
 protected:
 	static void _bind_methods();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "LuaObject.hpp"
 #include "LuaState.hpp"
 #include "LuaTable.hpp"
+#include "LuaThread.hpp"
 #include "LuaUserdata.hpp"
 #include "script-language/LuaCodeEdit.hpp"
 #include "script-language/LuaScript.hpp"
@@ -49,6 +50,7 @@ static void initialize(ModuleInitializationLevel level) {
 	// Lua object wrappers
 	ClassDB::register_abstract_class<LuaObject>();
 
+	ClassDB::register_abstract_class<LuaThread>();
 	ClassDB::register_abstract_class<LuaCoroutine>();
 	ClassDB::register_abstract_class<LuaFunction>();
 	ClassDB::register_abstract_class<LuaLightUserdata>();

--- a/src/utils/convert_godot_lua.cpp
+++ b/src/utils/convert_godot_lua.cpp
@@ -77,8 +77,15 @@ Variant to_variant(const sol::basic_object<ref_t>& object) {
 				return LuaObject::wrap_object<LuaUserdata>(object);
 			}
 
-		case sol::type::thread:
-			return LuaObject::wrap_object<LuaCoroutine>(object);
+		case sol::type::thread: {
+			sol::basic_thread<ref_t> thread(object);
+			if (thread.is_main_thread()) {
+				return LuaObject::wrap_object<LuaThread>(thread);
+			}
+			else {
+				return LuaObject::wrap_object<LuaCoroutine>(thread);
+			}
+		}
 
 		case sol::type::function:
 			return LuaObject::wrap_object<LuaFunction>(object);

--- a/test/gdscript_tests/LuaThread.gd
+++ b/test/gdscript_tests/LuaThread.gd
@@ -1,0 +1,15 @@
+extends RefCounted
+
+
+var lua_state: LuaState
+
+
+func _init():
+	lua_state = LuaState.new()
+
+
+func test_main_thread() -> bool:
+	var main_thread = lua_state.main_thread
+	assert(main_thread is LuaThread)
+	assert(main_thread.is_main_thread())
+	return true

--- a/test/gdscript_tests/LuaThread.gd.uid
+++ b/test/gdscript_tests/LuaThread.gd.uid
@@ -1,0 +1,1 @@
+uid://da0dxyhn0o8c5


### PR DESCRIPTION
This PR adds the `LuaThread` class as a superclass for `LuaCoroutine` as well as the `LuaState.main_thread` property.
This is groundwork for implementing hooks, since they can be set to the main thread as well as coroutines.