### PR TITLE
Use Ref<LuaFunction> instead of sol::protected_function in Lua methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 - Use `xcframework` instead of `dylib` in iOS exports
 - Crash when Lua errors, but the error object is not a string
+- Crash when reloading the GDExtension
 
 
 ## [0.3.0](https://github.com/gilzoide/lua-gdextension/releases/tag/0.3.0)

--- a/src/LuaCoroutine.cpp
+++ b/src/LuaCoroutine.cpp
@@ -80,6 +80,10 @@ sol::protected_function_result LuaCoroutine::_resume(lua_State *L, const Variant
 	return function_result;
 }
 
+Variant LuaCoroutine::invoke_lua(Ref<LuaFunction> f, const VariantArguments& args, bool return_lua_error) {
+	return invoke_lua(f->get_function(), args, return_lua_error);
+}
+
 Variant LuaCoroutine::invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error) {
 	LuaCoroutinePool pool(f.lua_state());
 	sol::thread coroutine = pool.acquire(f);

--- a/src/LuaCoroutine.hpp
+++ b/src/LuaCoroutine.hpp
@@ -46,6 +46,7 @@ public:
 	Variant resumev(const Array& args);
 	Variant resume(const Variant **argv, GDExtensionInt argc, GDExtensionCallError& error);
 
+	static Variant invoke_lua(Ref<LuaFunction> f, const VariantArguments& args, bool return_lua_error);
 	static Variant invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error);
 
 protected:

--- a/src/LuaFunction.cpp
+++ b/src/LuaFunction.cpp
@@ -49,6 +49,10 @@ Variant LuaFunction::invoke(const Variant **args, GDExtensionInt arg_count, GDEx
 	return invoke_lua(lua_object, VariantArguments(args, arg_count), true);
 }
 
+Variant LuaFunction::invoke_lua(Ref<LuaFunction> f, const VariantArguments& args, bool return_lua_error) {
+	return invoke_lua(f->get_function(), args, return_lua_error);
+}
+
 Variant LuaFunction::invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error) {
 	sol::protected_function_result result = f.call(args);
 	return to_variant(result, return_lua_error);

--- a/src/LuaFunction.hpp
+++ b/src/LuaFunction.hpp
@@ -42,6 +42,7 @@ public:
 	Variant invokev(const Array& args);
 	Variant invoke(const Variant **args, GDExtensionInt arg_count, GDExtensionCallError &error);
 
+	static Variant invoke_lua(Ref<LuaFunction> f, const VariantArguments& args, bool return_lua_error);
 	static Variant invoke_lua(const sol::protected_function& f, const VariantArguments& args, bool return_lua_error);
 
 	Callable to_callable() const;

--- a/src/LuaObject.hpp
+++ b/src/LuaObject.hpp
@@ -41,7 +41,7 @@ public:
 	uint64_t get_pointer_value() const;
 
 	template<typename Subclass, typename ref_t>
-	static Subclass *wrap_object(const sol::basic_object<ref_t>& lua_obj) {
+	static Ref<Subclass> wrap_object(const sol::basic_object<ref_t>& lua_obj) {
 		if (LuaObject **known_obj = known_objects.getptr(lua_obj.pointer())) {
 			return (Subclass *) *known_obj;
 		}

--- a/src/LuaState.cpp
+++ b/src/LuaState.cpp
@@ -189,15 +189,15 @@ Variant LuaState::do_file(const String& filename, LoadMode mode, LuaTable *env) 
 	return ::luagdextension::do_file(lua_state, filename, (sol::load_mode) mode, env);
 }
 
-LuaTable *LuaState::get_globals() const {
+Ref<LuaTable> LuaState::get_globals() const {
 	return LuaObject::wrap_object<LuaTable>(lua_state.globals());
 }
 
-LuaTable *LuaState::get_registry() const {
+Ref<LuaTable> LuaState::get_registry() const {
 	return LuaObject::wrap_object<LuaTable>(lua_state.registry());
 }
 
-LuaThread *LuaState::get_main_thread() const {
+Ref<LuaThread> LuaState::get_main_thread() const {
 	return LuaObject::wrap_object<LuaThread>(sol::thread(lua_state, lua_state));
 }
 

--- a/src/LuaState.hpp
+++ b/src/LuaState.hpp
@@ -114,9 +114,9 @@ public:
 	Variant do_string(const String& chunk, const String& chunkname = "", LuaTable *env = nullptr);
 	Variant do_file(const String& filename, LoadMode mode = LOAD_MODE_ANY, LuaTable *env = nullptr);
 
-	LuaTable *get_globals() const;
-	LuaTable *get_registry() const;
-	LuaThread *get_main_thread() const;
+	Ref<LuaTable> get_globals() const;
+	Ref<LuaTable> get_registry() const;
+	Ref<LuaThread> get_main_thread() const;
 
 	String get_package_path() const;
 	String get_package_cpath() const;

--- a/src/LuaThread.cpp
+++ b/src/LuaThread.cpp
@@ -92,7 +92,7 @@ void LuaThread::set_hook(Variant hook, BitField<HookMask> mask, int count) {
 	lua_push(L, hook);  // value (hook)
 	lua_rawset(L, -3);  // hooktable[L] = hook
 	lua_pop(L, 1);
-	if (hook) {
+	if (hook && mask) {
 		lua_sethook(L, hookf, mask, count);
 	}
 	else {

--- a/src/script-language/LuaScriptMethod.hpp
+++ b/src/script-language/LuaScriptMethod.hpp
@@ -25,6 +25,8 @@
 #include <sol/sol.hpp>
 #include <godot_cpp/core/object.hpp>
 
+#include "../LuaFunction.hpp"
+
 typedef struct lua_State lua_State;
 
 using namespace godot;
@@ -33,7 +35,7 @@ namespace luagdextension {
 
 struct LuaScriptMethod {
 	StringName name;
-	sol::protected_function method;
+	Ref<LuaFunction> method;
 	
 	LuaScriptMethod() = default;
 	LuaScriptMethod(const StringName& name, sol::protected_function method);

--- a/src/script-language/LuaScriptProperty.hpp
+++ b/src/script-language/LuaScriptProperty.hpp
@@ -23,9 +23,10 @@
 #define __LUA_SCRIPT_PROPERTY_HPP__
 
 #include <godot_cpp/core/property_info.hpp>
+#include <godot_cpp/classes/ref.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
-#include "../utils/custom_sol.hpp"
+#include "../LuaFunction.hpp"
 
 using namespace godot;
 
@@ -48,8 +49,8 @@ struct LuaScriptProperty {
 
 	StringName getter_name;
 	StringName setter_name;
-	sol::optional<sol::protected_function> getter;  // Variant getter(self)
-	sol::optional<sol::protected_function> setter;  // void setter(self, Variant value)
+	Ref<LuaFunction> getter;  // Variant getter(self)
+	Ref<LuaFunction> setter;  // void setter(self, Variant value)
 
 	bool get_value(LuaScriptInstance *self, Variant& r_value) const;
 	bool set_value(LuaScriptInstance *self, const Variant& value) const;


### PR DESCRIPTION
This avoids crashes when unloading some structs by saving an indirect reference to the LuaState.