### PR TITLE
Build for Linux platform using ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build_linux:
     name: ${{ matrix.platform }} (${{ matrix.arch }}, ${{ matrix.target }}, ${{ matrix.lua-runtime }})
-    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   MyScript.exported_texture_property = export({ type = Texture })
   ```
 - `is_instance_valid` utility function when opening `GODOT_UTILITY_FUNCTIONS` library
+- Support for older Linux distros using GLIBC on par with Ubuntu 22.04
 
 ### Changed
 - `LuaScriptInstance`'s data table is passed as `self` to methods instead of their owner `Object`


### PR DESCRIPTION
This should lower the minimum version of GLIBC required by the library.