### PR TITLE
Keep LuaScript metadata between reloads when loading script fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Increment reference count of returned `LuaState` from `LuaObject.get_lua_state`
 - Memory leak when indexing Variants with numbers
+- Avoid losing exported properties in scenes/resources when reloading a Lua script fails
 
 
 ## [0.6.1](https://github.com/gilzoide/lua-gdextension/releases/tag/0.6.1)

--- a/src/script-language/LuaScript.cpp
+++ b/src/script-language/LuaScript.cpp
@@ -117,7 +117,6 @@ void LuaScript::_set_source_code(const String &code) {
 
 Error LuaScript::_reload(bool keep_state) {
 	placeholder_fallback_enabled = true;
-	metadata.clear();
 
 	ImportBehavior import_behavior = get_import_behavior();
 	switch (import_behavior) {
@@ -150,6 +149,7 @@ Error LuaScript::_reload(bool keep_state) {
 	}
 	else if (LuaTable *table = Object::cast_to<LuaTable>(result)) {
 		placeholder_fallback_enabled = false;
+		metadata.clear();
 		metadata.setup(table->get_table());
 	}
 	return OK;


### PR DESCRIPTION
This avoids losing serialized properties from scenes while editing Lua scripts.