### PR TITLE
Add "function" to control flow keywords

### DIFF
--- a/src/script-language/LuaScriptLanguage.cpp
+++ b/src/script-language/LuaScriptLanguage.cpp
@@ -93,7 +93,7 @@ PackedStringArray LuaScriptLanguage::_get_reserved_words() const {
 bool LuaScriptLanguage::_is_control_flow_keyword(const String &keyword) const {
 	return godot::helpers::append_all(PackedStringArray(),
 		"break", "do", "else", "elseif", "end",
-		"for", "goto", "if", "in",
+		"for", "function", "goto", "if", "in",
 		"repeat", "return",
 		"then", "until", "while"
 	).has(keyword);


### PR DESCRIPTION
Hello! While editing scripts in Godot editor I noticed, that Lua functions are highlighted differently than it is done usually. `function` gets one color, and `end` gets another:
<img width="495" height="131" alt="Screenshot 2026-01-30 at 20 24 41" src="https://github.com/user-attachments/assets/7c518d4a-ba32-4ebf-8006-811986a1d740" />

Here is VSCode to compare:
<img width="515" height="133" alt="Screenshot 2026-01-30 at 20 24 24" src="https://github.com/user-attachments/assets/deb14d39-f8a9-4cdf-a9b4-5376fe5d6f85" />

Or Github:
```lua
function Logo:_ready()
    local timer = self:get_node("Timer")
    timer.timeout:connect(self._on_timeout)
    self.spawned:emit()
end
```

As far as I understand, adding `"function"` to control flow keywords (`_is_control_flow_keyword`) might fix this small issue.