### PR TITLE
Build Lua with LUA_USE_LONGJMP on web platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### Fixed
 - Exported properties of tool scripts now appear in the inspector
+- Yielding from coroutines now work in Web builds.
+  ⚠️ Warning: we're using `longjmp` because Web export templates do not ship with C++ exception support.
+  This works but **memory will leak**, since objects in the stack are not cleaned by the `longjmp` as they are when handling exceptions.
 
 
 ## [0.8.1](https://github.com/gilzoide/lua-gdextension/releases/tag/0.8.1)

--- a/tools/lua.py
+++ b/tools/lua.py
@@ -17,7 +17,9 @@ def generate(env):
         env.Append(CPPDEFINES="LUA_USE_ANDROID")
         if "32" in env["arch"]:
             env.Append(CPPDEFINES="LUA_USE_ANDROID_32")
-    elif env["platform"] != "web":
+    elif env["platform"] == "web":
+        env.Append(CPPDEFINES="LUA_USE_LONGJMP")
+    else:
         env.Append(CPPDEFINES="LUA_USE_POSIX")
 
     env.Append(CPPDEFINES=["SOL_USING_CXX_LUA=1"])


### PR DESCRIPTION
This works around Godot web template not being compiled with support for exceptions.
⚠️ Yielding from coroutines leak memory in this case!
Fixes #239.